### PR TITLE
Refactor: the function `services::torrent::Index::add_torrent`

### DIFF
--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -7,7 +7,7 @@ use crate::databases::sqlite::Sqlite;
 use crate::models::category::CategoryId;
 use crate::models::info_hash::InfoHash;
 use crate::models::response::TorrentsResponse;
-use crate::models::torrent::TorrentListing;
+use crate::models::torrent::{Metadata, TorrentListing};
 use crate::models::torrent_file::{DbTorrent, Torrent, TorrentFile};
 use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
@@ -196,9 +196,7 @@ pub trait Database: Sync + Send {
         original_info_hash: &InfoHash,
         torrent: &Torrent,
         uploader_id: UserId,
-        category_id: CategoryId,
-        title: &str,
-        description: &str,
+        metadata: &Metadata,
     ) -> Result<i64, Error>;
 
     /// Get `Torrent` from `InfoHash`.

--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -196,7 +196,7 @@ pub trait Database: Sync + Send {
         original_info_hash: &InfoHash,
         torrent: &Torrent,
         uploader_id: UserId,
-        category_id: i64,
+        category_id: CategoryId,
         title: &str,
         description: &str,
     ) -> Result<i64, Error>;

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -12,7 +12,7 @@ use crate::databases::database::{Category, Database, Driver, Sorting, TorrentCom
 use crate::models::category::CategoryId;
 use crate::models::info_hash::InfoHash;
 use crate::models::response::TorrentsResponse;
-use crate::models::torrent::TorrentListing;
+use crate::models::torrent::{Metadata, TorrentListing};
 use crate::models::torrent_file::{DbTorrent, DbTorrentAnnounceUrl, DbTorrentFile, Torrent, TorrentFile};
 use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
@@ -432,9 +432,7 @@ impl Database for Mysql {
         original_info_hash: &InfoHash,
         torrent: &Torrent,
         uploader_id: UserId,
-        category_id: CategoryId,
-        title: &str,
-        description: &str,
+        metadata: &Metadata,
     ) -> Result<i64, database::Error> {
         let info_hash = torrent.canonical_info_hash_hex();
         let canonical_info_hash = torrent.canonical_info_hash();
@@ -471,7 +469,7 @@ impl Database for Mysql {
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP())",
         )
         .bind(uploader_id)
-        .bind(category_id)
+        .bind(metadata.category_id)
         .bind(info_hash.to_lowercase())
         .bind(torrent.file_size())
         .bind(torrent.info.name.to_string())
@@ -585,11 +583,28 @@ impl Database for Mysql {
             return Err(e);
         }
 
+        // Insert tags
+
+        for tag_id in &metadata.tags {
+            let insert_torrent_tag_result = query("INSERT INTO torrust_torrent_tag_links (torrent_id, tag_id) VALUES (?, ?)")
+                .bind(torrent_id)
+                .bind(tag_id)
+                .execute(&mut tx)
+                .await
+                .map_err(|err| database::Error::ErrorWithText(err.to_string()));
+
+            // rollback transaction on error
+            if let Err(e) = insert_torrent_tag_result {
+                drop(tx.rollback().await);
+                return Err(e);
+            }
+        }
+
         let insert_torrent_info_result =
             query(r#"INSERT INTO torrust_torrent_info (torrent_id, title, description) VALUES (?, ?, NULLIF(?, ""))"#)
                 .bind(torrent_id)
-                .bind(title)
-                .bind(description)
+                .bind(metadata.title.clone())
+                .bind(metadata.description.clone())
                 .execute(&mut tx)
                 .await
                 .map_err(|e| match e {

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -436,7 +436,7 @@ impl Database for Mysql {
         title: &str,
         description: &str,
     ) -> Result<i64, database::Error> {
-        let info_hash = torrent.info_hash_hex();
+        let info_hash = torrent.canonical_info_hash_hex();
         let canonical_info_hash = torrent.canonical_info_hash();
 
         // open pool connection

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -432,7 +432,7 @@ impl Database for Mysql {
         original_info_hash: &InfoHash,
         torrent: &Torrent,
         uploader_id: UserId,
-        category_id: i64,
+        category_id: CategoryId,
         title: &str,
         description: &str,
     ) -> Result<i64, database::Error> {

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -422,7 +422,7 @@ impl Database for Sqlite {
         original_info_hash: &InfoHash,
         torrent: &Torrent,
         uploader_id: UserId,
-        category_id: i64,
+        category_id: CategoryId,
         title: &str,
         description: &str,
     ) -> Result<i64, database::Error> {

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -12,7 +12,7 @@ use crate::databases::database::{Category, Database, Driver, Sorting, TorrentCom
 use crate::models::category::CategoryId;
 use crate::models::info_hash::InfoHash;
 use crate::models::response::TorrentsResponse;
-use crate::models::torrent::TorrentListing;
+use crate::models::torrent::{Metadata, TorrentListing};
 use crate::models::torrent_file::{DbTorrent, DbTorrentAnnounceUrl, DbTorrentFile, Torrent, TorrentFile};
 use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
@@ -422,9 +422,7 @@ impl Database for Sqlite {
         original_info_hash: &InfoHash,
         torrent: &Torrent,
         uploader_id: UserId,
-        category_id: CategoryId,
-        title: &str,
-        description: &str,
+        metadata: &Metadata,
     ) -> Result<i64, database::Error> {
         let info_hash = torrent.canonical_info_hash_hex();
         let canonical_info_hash = torrent.canonical_info_hash();
@@ -461,7 +459,7 @@ impl Database for Sqlite {
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%S',DATETIME('now', 'utc')))",
         )
         .bind(uploader_id)
-        .bind(category_id)
+        .bind(metadata.category_id)
         .bind(info_hash.to_lowercase())
         .bind(torrent.file_size())
         .bind(torrent.info.name.to_string())
@@ -575,11 +573,28 @@ impl Database for Sqlite {
             return Err(e);
         }
 
+        // Insert tags
+
+        for tag_id in &metadata.tags {
+            let insert_torrent_tag_result = query("INSERT INTO torrust_torrent_tag_links (torrent_id, tag_id) VALUES (?, ?)")
+                .bind(torrent_id)
+                .bind(tag_id)
+                .execute(&mut tx)
+                .await
+                .map_err(|err| database::Error::ErrorWithText(err.to_string()));
+
+            // rollback transaction on error
+            if let Err(e) = insert_torrent_tag_result {
+                drop(tx.rollback().await);
+                return Err(e);
+            }
+        }
+
         let insert_torrent_info_result =
             query(r#"INSERT INTO torrust_torrent_info (torrent_id, title, description) VALUES (?, ?, NULLIF(?, ""))"#)
                 .bind(torrent_id)
-                .bind(title)
-                .bind(description)
+                .bind(metadata.title.clone())
+                .bind(metadata.description.clone())
                 .execute(&mut tx)
                 .await
                 .map_err(|e| match e {

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -426,7 +426,7 @@ impl Database for Sqlite {
         title: &str,
         description: &str,
     ) -> Result<i64, database::Error> {
-        let info_hash = torrent.info_hash_hex();
+        let info_hash = torrent.canonical_info_hash_hex();
         let canonical_info_hash = torrent.canonical_info_hash();
 
         // open pool connection

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ use derive_more::{Display, Error};
 use hyper::StatusCode;
 
 use crate::databases::database;
+use crate::models::torrent::MetadataError;
 
 pub type ServiceResult<V> = Result<V, ServiceError>;
 
@@ -201,6 +202,18 @@ impl From<serde_json::Error> for ServiceError {
     fn from(e: serde_json::Error) -> Self {
         eprintln!("{e}");
         ServiceError::InternalServerError
+    }
+}
+
+impl From<MetadataError> for ServiceError {
+    fn from(e: MetadataError) -> Self {
+        eprintln!("{e}");
+        match e {
+            MetadataError::MissingTorrentTitle | MetadataError::MissingTorrentCategoryName => {
+                ServiceError::MissingMandatoryMetadataFields
+            }
+            MetadataError::InvalidTorrentTitleLength => ServiceError::InvalidTorrentTitleLength,
+        }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,7 +6,7 @@ use hyper::StatusCode;
 
 use crate::databases::database;
 use crate::models::torrent::MetadataError;
-use crate::utils::parse_torrent::MetainfoFileDataError;
+use crate::utils::parse_torrent::DecodeTorrentFileError;
 
 pub type ServiceResult<V> = Result<V, ServiceError>;
 
@@ -216,12 +216,14 @@ impl From<MetadataError> for ServiceError {
     }
 }
 
-impl From<MetainfoFileDataError> for ServiceError {
-    fn from(e: MetainfoFileDataError) -> Self {
+impl From<DecodeTorrentFileError> for ServiceError {
+    fn from(e: DecodeTorrentFileError) -> Self {
         eprintln!("{e}");
         match e {
-            MetainfoFileDataError::InvalidBencodeData => ServiceError::InvalidTorrentFile,
-            MetainfoFileDataError::InvalidTorrentPiecesLength => ServiceError::InvalidTorrentTitleLength,
+            DecodeTorrentFileError::InvalidTorrentPiecesLength => ServiceError::InvalidTorrentTitleLength,
+            DecodeTorrentFileError::CannotBencodeInfoDict
+            | DecodeTorrentFileError::InvalidInfoDictionary
+            | DecodeTorrentFileError::InvalidBencodeData => ServiceError::InvalidTorrentFile,
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -209,9 +209,7 @@ impl From<MetadataError> for ServiceError {
     fn from(e: MetadataError) -> Self {
         eprintln!("{e}");
         match e {
-            MetadataError::MissingTorrentTitle | MetadataError::MissingTorrentCategoryName => {
-                ServiceError::MissingMandatoryMetadataFields
-            }
+            MetadataError::MissingTorrentTitle => ServiceError::MissingMandatoryMetadataFields,
             MetadataError::InvalidTorrentTitleLength => ServiceError::InvalidTorrentTitleLength,
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,7 @@ use hyper::StatusCode;
 
 use crate::databases::database;
 use crate::models::torrent::MetadataError;
+use crate::utils::parse_torrent::MetainfoFileDataError;
 
 pub type ServiceResult<V> = Result<V, ServiceError>;
 
@@ -211,6 +212,16 @@ impl From<MetadataError> for ServiceError {
         match e {
             MetadataError::MissingTorrentTitle => ServiceError::MissingMandatoryMetadataFields,
             MetadataError::InvalidTorrentTitleLength => ServiceError::InvalidTorrentTitleLength,
+        }
+    }
+}
+
+impl From<MetainfoFileDataError> for ServiceError {
+    fn from(e: MetainfoFileDataError) -> Self {
+        eprintln!("{e}");
+        match e {
+            MetainfoFileDataError::InvalidBencodeData => ServiceError::InvalidTorrentFile,
+            MetainfoFileDataError::InvalidTorrentPiecesLength => ServiceError::InvalidTorrentTitleLength,
         }
     }
 }

--- a/src/models/torrent.rs
+++ b/src/models/torrent.rs
@@ -1,6 +1,7 @@
 use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
 
+use super::category::CategoryId;
 use super::torrent_tag::TagId;
 
 const MIN_TORRENT_TITLE_LENGTH: usize = 3;
@@ -28,11 +29,8 @@ pub struct TorrentListing {
 
 #[derive(Debug, Display, PartialEq, Eq, Error)]
 pub enum MetadataError {
-    #[display(fmt = "Missing mandatory torrent title")]
+    #[display(fmt = "Missing mandatory torrent title.")]
     MissingTorrentTitle,
-
-    #[display(fmt = "Missing mandatory torrent category name")]
-    MissingTorrentCategoryName,
 
     #[display(fmt = "Torrent title is too short.")]
     InvalidTorrentTitleLength,
@@ -42,7 +40,7 @@ pub enum MetadataError {
 pub struct Metadata {
     pub title: String,
     pub description: String,
-    pub category: String,
+    pub category_id: CategoryId,
     pub tags: Vec<TagId>,
 }
 
@@ -53,13 +51,13 @@ impl Metadata {
     ///
     /// This function will return an error if the metadata fields do not have a
     /// valid format.
-    pub fn new(title: &str, description: &str, category: &str, tag_ids: &[TagId]) -> Result<Self, MetadataError> {
-        Self::validate_format(title, description, category, tag_ids)?;
+    pub fn new(title: &str, description: &str, category_id: CategoryId, tag_ids: &[TagId]) -> Result<Self, MetadataError> {
+        Self::validate_format(title, description, category_id, tag_ids)?;
 
         Ok(Self {
             title: title.to_owned(),
             description: description.to_owned(),
-            category: category.to_owned(),
+            category_id,
             tags: tag_ids.to_vec(),
         })
     }
@@ -76,13 +74,14 @@ impl Metadata {
     ///
     /// This function will return an error if any of the metadata fields does
     /// not have a valid format.
-    fn validate_format(title: &str, _description: &str, category: &str, _tag_ids: &[TagId]) -> Result<(), MetadataError> {
+    fn validate_format(
+        title: &str,
+        _description: &str,
+        _category_id: CategoryId,
+        _tag_ids: &[TagId],
+    ) -> Result<(), MetadataError> {
         if title.is_empty() {
             return Err(MetadataError::MissingTorrentTitle);
-        }
-
-        if category.is_empty() {
-            return Err(MetadataError::MissingTorrentCategoryName);
         }
 
         if title.len() < MIN_TORRENT_TITLE_LENGTH {

--- a/src/models/torrent_file.rs
+++ b/src/models/torrent_file.rs
@@ -133,13 +133,13 @@ impl Torrent {
     }
 
     #[must_use]
-    pub fn info_hash_hex(&self) -> String {
-        from_bytes(&self.calculate_info_hash_as_bytes()).to_lowercase()
+    pub fn canonical_info_hash(&self) -> InfoHash {
+        self.calculate_info_hash_as_bytes().into()
     }
 
     #[must_use]
-    pub fn canonical_info_hash(&self) -> InfoHash {
-        self.calculate_info_hash_as_bytes().into()
+    pub fn canonical_info_hash_hex(&self) -> String {
+        self.canonical_info_hash().to_hex_string()
     }
 
     #[must_use]
@@ -389,7 +389,7 @@ mod tests {
                 httpseeds: None,
             };
 
-            assert_eq!(torrent.info_hash_hex(), "79fa9e4a2927804fe4feab488a76c8c2d3d1cdca");
+            assert_eq!(torrent.canonical_info_hash_hex(), "79fa9e4a2927804fe4feab488a76c8c2d3d1cdca");
         }
 
         mod infohash_should_be_calculated_for {
@@ -430,7 +430,7 @@ mod tests {
                     httpseeds: None,
                 };
 
-                assert_eq!(torrent.info_hash_hex(), "79fa9e4a2927804fe4feab488a76c8c2d3d1cdca");
+                assert_eq!(torrent.canonical_info_hash_hex(), "79fa9e4a2927804fe4feab488a76c8c2d3d1cdca");
             }
 
             #[test]
@@ -469,7 +469,7 @@ mod tests {
                     httpseeds: None,
                 };
 
-                assert_eq!(torrent.info_hash_hex(), "aa2aca91ab650c4d249c475ca3fa604f2ccb0d2a");
+                assert_eq!(torrent.canonical_info_hash_hex(), "aa2aca91ab650c4d249c475ca3fa604f2ccb0d2a");
             }
 
             #[test]
@@ -504,7 +504,7 @@ mod tests {
                     httpseeds: None,
                 };
 
-                assert_eq!(torrent.info_hash_hex(), "ccc1cf4feb59f3fa85c96c9be1ebbafcfe8a9cc8");
+                assert_eq!(torrent.canonical_info_hash_hex(), "ccc1cf4feb59f3fa85c96c9be1ebbafcfe8a9cc8");
             }
 
             #[test]
@@ -539,7 +539,7 @@ mod tests {
                     httpseeds: None,
                 };
 
-                assert_eq!(torrent.info_hash_hex(), "d3a558d0a19aaa23ba6f9f430f40924d10fefa86");
+                assert_eq!(torrent.canonical_info_hash_hex(), "d3a558d0a19aaa23ba6f9f430f40924d10fefa86");
             }
         }
     }

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -136,9 +136,7 @@ impl Index {
 
         let (mut torrent, original_info_hash) = decode_and_validate_torrent_file(&add_torrent_req.torrent_buffer)?;
 
-        // Customize the announce URLs with the linked tracker URL
-        // and remove others if the torrent is private.
-        torrent.set_announce_urls(&self.configuration).await;
+        self.customize_announcement_info_for(&mut torrent).await;
 
         let canonical_info_hash = torrent.canonical_info_hash();
 
@@ -231,6 +229,13 @@ impl Index {
         )?;
 
         Ok(metadata)
+    }
+
+    async fn customize_announcement_info_for(&self, torrent: &mut Torrent) {
+        let settings = self.configuration.settings.read().await;
+        let tracker_url = settings.tracker.url.clone();
+        torrent.set_announce_to(&tracker_url);
+        torrent.reset_announce_list_if_private();
     }
 
     /// Gets a torrent from the Index.

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -148,13 +148,16 @@ impl Index {
 
         // Synchronous secondary tasks
 
+        // code-review: consider moving this to a background task
         self.import_torrent_statistics_from_tracker(torrent_id, &torrent.canonical_info_hash())
             .await;
 
-        // Secondary task: whitelist torrent on the tracker
-
-        // We always whitelist the torrent on the tracker because even if the tracker mode is `public`
-        // it could be changed to `private` later on.
+        // We always whitelist the torrent on the tracker because
+        // even if the tracker mode is `public` it could be changed to `private`
+        // later on.
+        //
+        // code-review: maybe we should consider adding a new feature to
+        // whitelist  all torrents from the admin panel if that change happens.
         if let Err(e) = self
             .tracker_service
             .whitelist_info_hash(torrent.canonical_info_hash_hex())

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -129,7 +129,7 @@ impl Index {
         add_torrent_req: AddTorrentRequest,
         user_id: UserId,
     ) -> Result<AddTorrentResponse, ServiceError> {
-        // Authorization: only authenticated users ere allowed to upload torrents
+        // Guard that the users exists
         let _user = self.user_repository.get_compact(&user_id).await?;
 
         let metadata = self.validate_and_build_metadata(&add_torrent_req).await?;

--- a/src/utils/parse_torrent.rs
+++ b/src/utils/parse_torrent.rs
@@ -99,7 +99,7 @@ mod tests {
         // The infohash is not the original infohash of the torrent file,
         // but the infohash of the info dictionary without the custom keys.
         assert_eq!(
-            torrent.info_hash_hex(),
+            torrent.canonical_info_hash_hex(),
             "8aa01a4c816332045ffec83247ccbc654547fedf".to_string()
         );
     }

--- a/src/utils/parse_torrent.rs
+++ b/src/utils/parse_torrent.rs
@@ -10,12 +10,18 @@ use crate::models::info_hash::InfoHash;
 use crate::models::torrent_file::Torrent;
 
 #[derive(Debug, Display, PartialEq, Eq, Error)]
-pub enum MetainfoFileDataError {
+pub enum DecodeTorrentFileError {
     #[display(fmt = "Torrent data could not be decoded from the bencoded format.")]
     InvalidBencodeData,
 
+    #[display(fmt = "Torrent info dictionary key could not be decoded from the bencoded format.")]
+    InvalidInfoDictionary,
+
     #[display(fmt = "Torrent has an invalid pieces key length. It should be a multiple of 20.")]
     InvalidTorrentPiecesLength,
+
+    #[display(fmt = "Cannot bencode the parsed `info` dictionary again to generate the info-hash.")]
+    CannotBencodeInfoDict,
 }
 
 /// It decodes and validate an array of bytes containing a torrent file.
@@ -31,15 +37,15 @@ pub enum MetainfoFileDataError {
 ///
 /// - The torrent file is not a valid bencoded file.
 /// - The pieces key has a length that is not a multiple of 20.
-pub fn decode_and_validate_torrent_file(bytes: &[u8]) -> Result<(Torrent, InfoHash), MetainfoFileDataError> {
-    let original_info_hash = calculate_info_hash(bytes);
+pub fn decode_and_validate_torrent_file(bytes: &[u8]) -> Result<(Torrent, InfoHash), DecodeTorrentFileError> {
+    let original_info_hash = calculate_info_hash(bytes)?;
 
-    let torrent = decode_torrent(bytes).map_err(|_| MetainfoFileDataError::InvalidBencodeData)?;
+    let torrent = decode_torrent(bytes).map_err(|_| DecodeTorrentFileError::InvalidBencodeData)?;
 
     // Make sure that the pieces key has a length that is a multiple of 20
     if let Some(pieces) = torrent.info.pieces.as_ref() {
         if pieces.as_ref().len() % 20 != 0 {
-            return Err(MetainfoFileDataError::InvalidTorrentPiecesLength);
+            return Err(DecodeTorrentFileError::InvalidTorrentPiecesLength);
         }
     }
 
@@ -77,30 +83,34 @@ pub fn encode_torrent(torrent: &Torrent) -> Result<Vec<u8>, Error> {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-struct MetainfoFile {
+struct ParsedInfoDictFromMetainfoFile {
     pub info: Value,
 }
 
 /// Calculates the `InfoHash` from a the torrent file binary data.
 ///
-/// # Panics
+/// # Errors
 ///
-/// This function will panic if the torrent file is not a valid bencoded file
-/// or if the info dictionary cannot be bencoded.
-#[must_use]
-pub fn calculate_info_hash(bytes: &[u8]) -> InfoHash {
+/// This function will return an error if:
+///
+/// - The torrent file is not a valid bencoded torrent file containing an `info`
+///  dictionary key.
+/// - The original torrent info-hash cannot be bencoded from the parsed `info`
+/// dictionary is not a valid bencoded dictionary.
+pub fn calculate_info_hash(bytes: &[u8]) -> Result<InfoHash, DecodeTorrentFileError> {
     // Extract the info dictionary
-    let metainfo: MetainfoFile = serde_bencode::from_bytes(bytes).expect("Torrent file cannot be parsed from bencoded format");
+    let metainfo: ParsedInfoDictFromMetainfoFile =
+        serde_bencode::from_bytes(bytes).map_err(|_| DecodeTorrentFileError::InvalidInfoDictionary)?;
 
     // Bencode the info dictionary
-    let info_dict_bytes = serde_bencode::to_bytes(&metainfo.info).expect("Info dictionary cannot by bencoded");
+    let info_dict_bytes = serde_bencode::to_bytes(&metainfo.info).map_err(|_| DecodeTorrentFileError::CannotBencodeInfoDict)?;
 
     // Calculate the SHA-1 hash of the bencoded info dictionary
     let mut hasher = Sha1::new();
     hasher.update(&info_dict_bytes);
     let result = hasher.finalize();
 
-    InfoHash::from_bytes(&result)
+    Ok(InfoHash::from_bytes(&result))
 }
 
 #[cfg(test)]
@@ -117,7 +127,7 @@ mod tests {
             "tests/fixtures/torrents/6c690018c5786dbbb00161f62b0712d69296df97_with_custom_info_dict_key.torrent",
         );
 
-        let original_info_hash = super::calculate_info_hash(&std::fs::read(torrent_path).unwrap());
+        let original_info_hash = super::calculate_info_hash(&std::fs::read(torrent_path).unwrap()).unwrap();
 
         assert_eq!(
             original_info_hash,

--- a/src/web/api/v1/contexts/torrent/handlers.rs
+++ b/src/web/api/v1/contexts/torrent/handlers.rs
@@ -396,7 +396,7 @@ async fn build_add_torrent_request_from_payload(mut payload: Multipart) -> Resul
     Ok(AddTorrentRequest {
         title,
         description,
-        category,
+        category_name: category,
         tags,
         torrent_buffer: torrent_cursor.into_inner(),
     })

--- a/src/web/api/v1/contexts/torrent/handlers.rs
+++ b/src/web/api/v1/contexts/torrent/handlers.rs
@@ -100,7 +100,11 @@ pub async fn download_torrent_handler(
             return ServiceError::InternalServerError.into_response();
         };
 
-        torrent_file_response(bytes, &format!("{}.torrent", torrent.info.name), &torrent.info_hash_hex())
+        torrent_file_response(
+            bytes,
+            &format!("{}.torrent", torrent.info.name),
+            &torrent.canonical_info_hash_hex(),
+        )
     }
 }
 
@@ -307,7 +311,11 @@ pub async fn create_random_torrent_handler(State(_app_data): State<Arc<AppData>>
         return ServiceError::InternalServerError.into_response();
     };
 
-    torrent_file_response(bytes, &format!("{}.torrent", torrent.info.name), &torrent.info_hash_hex())
+    torrent_file_response(
+        bytes,
+        &format!("{}.torrent", torrent.info.name),
+        &torrent.canonical_info_hash_hex(),
+    )
 }
 
 /// Extracts the [`TorrentRequest`] from the multipart form payload.

--- a/tests/common/client.rs
+++ b/tests/common/client.rs
@@ -253,7 +253,7 @@ impl Http {
                 .bearer_auth(token)
                 .send()
                 .await
-                .unwrap(),
+                .expect("failed to send multipart request with token"),
             None => reqwest::Client::builder()
                 .build()
                 .unwrap()
@@ -261,7 +261,7 @@ impl Http {
                 .multipart(form)
                 .send()
                 .await
-                .unwrap(),
+                .expect("failed to send multipart request without token"),
         };
         TextResponse::from(response).await
     }

--- a/tests/common/contexts/torrent/fixtures.rs
+++ b/tests/common/contexts/torrent/fixtures.rs
@@ -18,10 +18,12 @@ use crate::common::contexts::category::fixtures::software_category_name;
 /// Information about a torrent that is going to be added to the index.
 #[derive(Clone)]
 pub struct TorrentIndexInfo {
+    // Metadata
     pub title: String,
     pub description: String,
     pub category: String,
     pub tags: Option<Vec<i64>>,
+    // Other fields
     pub torrent_file: BinaryFile,
     pub name: String,
 }

--- a/tests/e2e/web/api/v1/contexts/torrent/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/contract.rs
@@ -317,7 +317,8 @@ mod for_guests {
             // Download
             let response = client.download_torrent(&test_torrent.file_info_hash()).await;
 
-            let downloaded_torrent_info_hash = calculate_info_hash(&response.bytes);
+            let downloaded_torrent_info_hash =
+                calculate_info_hash(&response.bytes).expect("failed to calculate info-hash of the downloaded torrent");
 
             assert_eq!(
                 downloaded_torrent_info_hash.to_hex_string(),
@@ -598,7 +599,6 @@ mod for_authenticated_users {
             use crate::e2e::web::api::v1::contexts::user::steps::new_logged_in_user;
 
             #[tokio::test]
-            #[should_panic]
             async fn contains_a_bencoded_dictionary_with_the_info_key_in_order_to_calculate_the_original_info_hash() {
                 let mut env = TestEnv::new();
                 env.start(api::Version::V1).await;
@@ -614,7 +614,9 @@ mod for_authenticated_users {
 
                 let form: UploadTorrentMultipartForm = test_torrent.index_info.into();
 
-                let _response = client.upload_torrent(form.into()).await;
+                let response = client.upload_torrent(form.into()).await;
+
+                assert_eq!(response.status, 400);
             }
 
             #[tokio::test]

--- a/tests/e2e/web/api/v1/contexts/torrent/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/contract.rs
@@ -396,7 +396,10 @@ mod for_guests {
 
         // The returned torrent info-hash should be the same as the first torrent
         assert_eq!(response.status, 200);
-        assert_eq!(torrent.info_hash_hex(), first_torrent_canonical_info_hash.to_hex_string());
+        assert_eq!(
+            torrent.canonical_info_hash_hex(),
+            first_torrent_canonical_info_hash.to_hex_string()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
- [x] Reorganize tests in torrent context contract.
- [x] Add more tests before the refactoring.
- [x] Refactorings.