### PR TITLE
fix: rework error handling for add_category

### DIFF
--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -81,7 +81,6 @@ pub enum Error {
     UsernameTaken,
     EmailTaken,
     UserNotFound,
-    CategoryAlreadyExists,
     CategoryNotFound,
     TagAlreadyExists,
     TagNotFound,

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -249,17 +249,7 @@ impl Database for Mysql {
             .execute(&self.pool)
             .await
             .map(|v| i64::try_from(v.last_insert_id()).expect("last ID is larger than i64"))
-            .map_err(|e| match e {
-                sqlx::Error::Database(err) => {
-                    log::error!("DB error: {:?}", err);
-                    if err.message().contains("Duplicate entry") && err.message().contains("name") {
-                        database::Error::CategoryAlreadyExists
-                    } else {
-                        database::Error::Error
-                    }
-                }
-                _ => database::Error::Error,
-            })
+            .map_err(|_| database::Error::Error)
     }
 
     async fn get_category_from_id(&self, category_id: i64) -> Result<Category, database::Error> {

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -239,17 +239,7 @@ impl Database for Sqlite {
             .execute(&self.pool)
             .await
             .map(|v| v.last_insert_rowid())
-            .map_err(|e| match e {
-                sqlx::Error::Database(err) => {
-                    log::error!("DB error: {:?}", err);
-                    if err.message().contains("UNIQUE") && err.message().contains("name") {
-                        database::Error::CategoryAlreadyExists
-                    } else {
-                        database::Error::Error
-                    }
-                }
-                _ => database::Error::Error,
-            })
+            .map_err(|_| database::Error::Error)
     }
 
     async fn get_category_from_id(&self, category_id: i64) -> Result<Category, database::Error> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -288,7 +288,6 @@ pub fn map_database_error_to_service_error(error: &database::Error) -> ServiceEr
         database::Error::UsernameTaken => ServiceError::UsernameTaken,
         database::Error::EmailTaken => ServiceError::EmailTaken,
         database::Error::UserNotFound => ServiceError::UserNotFound,
-        database::Error::CategoryAlreadyExists => ServiceError::CategoryAlreadyExists,
         database::Error::CategoryNotFound => ServiceError::InvalidCategory,
         database::Error::TagAlreadyExists => ServiceError::TagAlreadyExists,
         database::Error::TagNotFound => ServiceError::InvalidTag,

--- a/src/services/category.rs
+++ b/src/services/category.rs
@@ -48,9 +48,10 @@ impl Service {
 
         // Try to get the category by name to check if it already exists
         match self.category_repository.get_by_name(trimmed_name).await {
-            // Return ServiceError::CategoryAlreadyExists when the category already exists
+            // Return ServiceError::CategoryAlreadyExists if the category exists
             Ok(_) => Err(ServiceError::CategoryAlreadyExists),
             Err(e) => match e {
+                // Otherwise try to create it
                 DatabaseError::CategoryNotFound => match self.category_repository.add(trimmed_name).await {
                     Ok(id) => Ok(id),
                     Err(_) => Err(ServiceError::DatabaseError),

--- a/src/services/category.rs
+++ b/src/services/category.rs
@@ -44,10 +44,15 @@ impl Service {
             return Err(ServiceError::CategoryNameEmpty);
         }
 
-        match self.category_repository.add(trimmed_name).await {
-            Ok(id) => Ok(id),
+        // Try to get the category by name to check if it already exists
+        match self.category_repository.get_by_name(trimmed_name).await {
+            // Return ServiceError::CategoryAlreadyExists when the category already exists
+            Ok(_) => Err(ServiceError::CategoryAlreadyExists),
             Err(e) => match e {
-                DatabaseError::CategoryAlreadyExists => Err(ServiceError::CategoryAlreadyExists),
+                DatabaseError::CategoryNotFound => match self.category_repository.add(trimmed_name).await {
+                    Ok(id) => Ok(id),
+                    Err(_) => Err(ServiceError::DatabaseError),
+                },
                 _ => Err(ServiceError::DatabaseError),
             },
         }

--- a/src/services/category.rs
+++ b/src/services/category.rs
@@ -28,6 +28,8 @@ impl Service {
     /// It returns an error if:
     ///
     /// * The user does not have the required permissions.
+    /// * The category name is empty.
+    /// * The category already exists.
     /// * There is a database error.
     pub async fn add_category(&self, category_name: &str, user_id: &UserId) -> Result<i64, ServiceError> {
         let user = self.user_repository.get_compact(user_id).await?;

--- a/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
+++ b/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
@@ -116,16 +116,7 @@ impl SqliteDatabaseV2_0_0 {
             .execute(&self.pool)
             .await
             .map(|v| v.last_insert_rowid())
-            .map_err(|e| match e {
-                sqlx::Error::Database(err) => {
-                    if err.message().contains("UNIQUE") && err.message().contains("name") {
-                        database::Error::CategoryAlreadyExists
-                    } else {
-                        database::Error::Error
-                    }
-                }
-                _ => database::Error::Error,
-            })
+            .map_err(|_| database::Error::Error)
     }
 
     pub async fn insert_category(&self, category: &CategoryRecordV2) -> Result<i64, sqlx::Error> {


### PR DESCRIPTION
Hello !

This PR fixes [#253](https://github.com/torrust/torrust-index/issues/253).
I think that we can keep the unique constraint in the DB on top of this change as proposed by @josecelano in the original issue

Following this change, I think that we should move some of the error logic that is inside the databases crate to the services one.
All of these errors should not be raised at database level but rather at the service level:
- `database::Error::UsernameTaken`
- `database::Error::EmailTaken`
- `database::Error::TagAlreadyExists`
- `database::Error::TorrentAlreadyExists`
- `database::Error::TorrentTitleAlreadyExists`

This will permit to avoid using database error message parsing which is implementation specific and error prone (like [here](https://github.com/torrust/torrust-index/blob/41c80f359490a156e61bc5670874708f350ca75b/src/databases/sqlite.rs#L612C43-L612C43) or [here](https://github.com/torrust/torrust-index/blob/41c80f359490a156e61bc5670874708f350ca75b/src/databases/mysql.rs#L831))

I'd be happy to open another PR to rework the listed errors if you aggree with this new approach
That's my first contribution here, and I am also pretty new to the Rust ecosystem so don't hesitate to tell me if anything's wrong