### PR TITLE
Refactor: extract duplicate function `wait_for_container_to_be_healthy`

### DIFF
--- a/contrib/dev-tools/container/e2e/mysql/run-e2e-tests.sh
+++ b/contrib/dev-tools/container/e2e/mysql/run-e2e-tests.sh
@@ -10,32 +10,6 @@ TORRUST_TRACKER_USER_UID=$CURRENT_USER_ID
 export USER_ID
 export TORRUST_TRACKER_USER_UID
 
-# todo: remove duplicate funtion
-wait_for_container_to_be_healthy() {
-    local container_name="$1"
-    local max_retries="$2"
-    local retry_interval="$3"
-    local retry_count=0
-
-    while [ $retry_count -lt "$max_retries" ]; do
-        container_health="$(docker inspect --format='{{json .State.Health}}' "$container_name")"
-        if [ "$container_health" != "{}" ]; then
-            container_status="$(echo "$container_health" | jq -r '.Status')"
-            if [ "$container_status" == "healthy" ]; then
-                echo "Container $container_name is healthy"
-                return 0
-            fi
-        fi
-
-        retry_count=$((retry_count + 1))
-        echo "Waiting for container $container_name to become healthy (attempt $retry_count of $max_retries)..."
-        sleep "$retry_interval"
-    done
-
-    echo "Timeout reached, container $container_name is not healthy"
-    return 1
-}
-
 # Install tool to create torrent files.
 # It's needed by some tests to generate and parse test torrent files.
 cargo install imdl || exit 1
@@ -50,7 +24,8 @@ echo "Running E2E tests using MySQL ..."
 # Start E2E testing environment
 ./contrib/dev-tools/container/e2e/mysql/e2e-env-up.sh || exit 1
 
-wait_for_container_to_be_healthy torrust-mysql-1 10 3
+# Wait for conatiners to be healthy
+./contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh torrust-mysql-1 10 3
 # todo: implement healthchecks for tracker and index and wait until they are healthy
 #wait_for_container torrust-tracker-1 10 3
 #wait_for_container torrust-idx-back-1 10 3

--- a/contrib/dev-tools/container/e2e/sqlite/run-e2e-tests.sh
+++ b/contrib/dev-tools/container/e2e/sqlite/run-e2e-tests.sh
@@ -10,32 +10,6 @@ TORRUST_TRACKER_USER_UID=$CURRENT_USER_ID
 export USER_ID
 export TORRUST_TRACKER_USER_UID
 
-# todo: remove duplicate funtion
-wait_for_container_to_be_healthy() {
-    local container_name="$1"
-    local max_retries="$2"
-    local retry_interval="$3"
-    local retry_count=0
-
-    while [ $retry_count -lt "$max_retries" ]; do
-        container_health="$(docker inspect --format='{{json .State.Health}}' "$container_name")"
-        if [ "$container_health" != "{}" ]; then
-            container_status="$(echo "$container_health" | jq -r '.Status')"
-            if [ "$container_status" == "healthy" ]; then
-                echo "Container $container_name is healthy"
-                return 0
-            fi
-        fi
-
-        retry_count=$((retry_count + 1))
-        echo "Waiting for container $container_name to become healthy (attempt $retry_count of $max_retries)..."
-        sleep "$retry_interval"
-    done
-
-    echo "Timeout reached, container $container_name is not healthy"
-    return 1
-}
-
 # Install tool to create torrent files.
 # It's needed by some tests to generate and parse test torrent files.
 cargo install imdl || exit 1
@@ -51,7 +25,8 @@ echo "Running E2E tests using SQLite ..."
 # Start E2E testing environment
 ./contrib/dev-tools/container/e2e/sqlite/e2e-env-up.sh || exit 1
 
-wait_for_container_to_be_healthy torrust-mysql-1 10 3
+# Wait for conatiners to be healthy
+./contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh torrust-mysql-1 10 3
 # todo: implement healthchecks for tracker and index and wait until they are healthy
 #wait_for_container torrust-tracker-1 10 3
 #wait_for_container torrust-idx-back-1 10 3

--- a/contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh
+++ b/contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+wait_for_container_to_be_healthy() {
+    local container_name="$1"
+    local max_retries="$2"
+    local retry_interval="$3"
+    local retry_count=0
+
+    while [ $retry_count -lt "$max_retries" ]; do
+        container_health="$(docker inspect --format='{{json .State.Health}}' "$container_name")"
+        if [ "$container_health" != "{}" ]; then
+            container_status="$(echo "$container_health" | jq -r '.Status')"
+            if [ "$container_status" == "healthy" ]; then
+                echo "Container $container_name is healthy"
+                return 0
+            fi
+        fi
+
+        retry_count=$((retry_count + 1))
+        echo "Waiting for container $container_name to become healthy (attempt $retry_count of $max_retries)..."
+        sleep "$retry_interval"
+    done
+
+    echo "Timeout reached, container $container_name is not healthy"
+    return 1
+}


### PR DESCRIPTION
Extract duplicate function `wait_for_container_to_be_healthy` in E2E test scripts.