### PR TITLE
Inject E2E DB connection info with environent  variable

### DIFF
--- a/contrib/dev-tools/container/e2e/mysql/run-e2e-tests.sh
+++ b/contrib/dev-tools/container/e2e/mysql/run-e2e-tests.sh
@@ -41,7 +41,11 @@ docker ps
 ./contrib/dev-tools/container/e2e/mysql/install.sh || exit 1
 
 # Run E2E tests with shared app instance
-TORRUST_INDEX_E2E_SHARED=true TORRUST_INDEX_E2E_PATH_CONFIG="./share/default/config/index.e2e.container.mysql.toml" cargo test || exit 1
+TORRUST_INDEX_E2E_SHARED=true \
+    TORRUST_INDEX_E2E_PATH_CONFIG="./share/default/config/index.e2e.container.mysql.toml" \
+    TORRUST_INDEX_E2E_DB_CONNECT_URL="mysql://root:root_secret_password@localhost:3306/torrust_index_e2e_testing" \
+    cargo test \
+    || exit 1
 
 # Stop E2E testing environment
 ./contrib/dev-tools/container/e2e/mysql/e2e-env-down.sh || exit 1

--- a/contrib/dev-tools/container/e2e/sqlite/run-e2e-tests.sh
+++ b/contrib/dev-tools/container/e2e/sqlite/run-e2e-tests.sh
@@ -39,7 +39,11 @@ sleep 20s
 docker ps
 
 # Run E2E tests with shared app instance
-TORRUST_INDEX_E2E_SHARED=true TORRUST_INDEX_E2E_PATH_CONFIG="./share/default/config/index.e2e.container.sqlite3.toml" cargo test || exit 1
+TORRUST_INDEX_E2E_SHARED=true \
+    TORRUST_INDEX_E2E_PATH_CONFIG="./share/default/config/index.e2e.container.sqlite3.toml" \
+    TORRUST_INDEX_E2E_DB_CONNECT_URL="sqlite://./storage/index/lib/database/e2e_testing_sqlite3.db?mode=rwc" \
+    cargo test \
+    || exit 1
 
 # Stop E2E testing environment
 ./contrib/dev-tools/container/e2e/sqlite/e2e-env-down.sh || exit 1

--- a/tests/e2e/config.rs
+++ b/tests/e2e/config.rs
@@ -23,6 +23,9 @@ pub const DEFAULT_PATH_CONFIG: &str = "./share/default/config/index.development.
 /// If present, E2E tests will run against a shared instance of the server
 pub const ENV_VAR_INDEX_SHARED: &str = "TORRUST_INDEX_E2E_SHARED";
 
+/// `SQLx` connection string to connect to the E2E database
+pub const ENV_VAR_DB_CONNECT_URL: &str = "TORRUST_INDEX_E2E_DB_CONNECT_URL";
+
 /// It loads the application configuration from the environment.
 ///
 /// There are two methods to inject the configuration:


### PR DESCRIPTION
How to run E2E tests example:

```bash
TORRUST_INDEX_E2E_SHARED=true \
    TORRUST_INDEX_E2E_PATH_CONFIG="./share/default/config/index.e2e.container.mysql.toml" \
    TORRUST_INDEX_E2E_DB_CONNECT_URL="mysql://root:root_secret_password@localhost:3306/torrust_index_e2e_testing" \
    cargo test \
    || exit 1
```

The new `TORRUST_INDEX_E2E_DB_CONNECT_URL` is used to connect to the E2E DB directly. IT's needed for some tests to set the initial state needed for the test, when it's not possible do do it otherwise.