### PR TITLE
Wait for Tracker container to be healthy

### DIFF
--- a/contrib/dev-tools/container/e2e/mysql/run-e2e-tests.sh
+++ b/contrib/dev-tools/container/e2e/mysql/run-e2e-tests.sh
@@ -29,10 +29,8 @@ echo "Running E2E tests using MySQL ..."
 
 # Wait for conatiners to be healthy
 ./contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh torrust-mysql-1 10 3 || exit 1
-# todo: implement healthchecks for the tracker and wait until it's healthy
-#./contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh torrust-tracker-1 10 3
+./contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh torrust-tracker-1 10 3 || exit 1
 ./contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh  torrust-index-1 10 3 || exit 1
-sleep 20s
 
 # Just to make sure that everything is up and running
 docker ps

--- a/contrib/dev-tools/container/e2e/sqlite/run-e2e-tests.sh
+++ b/contrib/dev-tools/container/e2e/sqlite/run-e2e-tests.sh
@@ -30,10 +30,8 @@ echo "Running E2E tests using SQLite ..."
 
 # Wait for conatiners to be healthy
 ./contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh torrust-mysql-1 10 3 || exit 1
-# todo: implement healthchecks for the tracker and wait until it's healthy
-#./contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh torrust-tracker-1 10 3
+./contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh torrust-tracker-1 10 3 || exit 1
 ./contrib/dev-tools/container/functions/wait_for_container_to_be_healthy.sh  torrust-index-1 10 3 || exit 1
-sleep 20s
 
 # Just to make sure that everything is up and running
 docker ps

--- a/share/default/config/tracker.container.mysql.toml
+++ b/share/default/config/tracker.container.mysql.toml
@@ -36,3 +36,6 @@ ssl_key_path = "/var/lib/torrust/tracker/tls/localhost.key"
 
 [http_api.access_tokens]
 admin = "MyAccessToken"
+
+[health_check_api]
+bind_address = "127.0.0.1:1313"

--- a/share/default/config/tracker.container.sqlite3.toml
+++ b/share/default/config/tracker.container.sqlite3.toml
@@ -36,3 +36,6 @@ ssl_key_path = "/var/lib/torrust/tracker/tls/localhost.key"
 
 [http_api.access_tokens]
 admin = "MyAccessToken"
+
+[health_check_api]
+bind_address = "127.0.0.1:1313"

--- a/share/default/config/tracker.e2e.container.sqlite3.toml
+++ b/share/default/config/tracker.e2e.container.sqlite3.toml
@@ -36,3 +36,7 @@ ssl_key_path = "/var/lib/torrust/tracker/tls/localhost.key"
 
 [http_api.access_tokens]
 admin = "MyAccessToken"
+
+[health_check_api]
+bind_address = "127.0.0.1:1313"
+


### PR DESCRIPTION
Instead of just waiting 20 seconds. Now the Tracker container has `HEALTHCHECK` instruction.

See: https://github.com/torrust/torrust-tracker/issues/508