### PR TITLE
Encode tracker API token in  HTTP requests

### DIFF
--- a/src/tracker/api.rs
+++ b/src/tracker/api.rs
@@ -34,14 +34,13 @@ impl Client {
     ///
     /// Will return an error if the HTTP request fails.
     pub async fn whitelist_torrent(&self, info_hash: &str) -> Result<Response, Error> {
-        let request_url = format!(
-            "{}/whitelist/{}?token={}",
-            self.base_url, info_hash, self.connection_info.token
-        );
+        let request_url = format!("{}/whitelist/{}", self.base_url, info_hash);
 
         let client = reqwest::Client::new();
 
-        client.post(request_url).send().await
+        let params = [("token", &self.connection_info.token)];
+
+        client.post(request_url).query(&params).send().await
     }
 
     /// Remove a torrent from the tracker whitelist.
@@ -50,14 +49,13 @@ impl Client {
     ///
     /// Will return an error if the HTTP request fails.
     pub async fn remove_torrent_from_whitelist(&self, info_hash: &str) -> Result<Response, Error> {
-        let request_url = format!(
-            "{}/whitelist/{}?token={}",
-            self.base_url, info_hash, self.connection_info.token
-        );
+        let request_url = format!("{}/whitelist/{}", self.base_url, info_hash);
 
         let client = reqwest::Client::new();
 
-        client.delete(request_url).send().await
+        let params = [("token", &self.connection_info.token)];
+
+        client.delete(request_url).query(&params).send().await
     }
 
     /// Retrieve a new tracker key.
@@ -66,14 +64,13 @@ impl Client {
     ///
     /// Will return an error if the HTTP request fails.
     pub async fn retrieve_new_tracker_key(&self, token_valid_seconds: u64) -> Result<Response, Error> {
-        let request_url = format!(
-            "{}/key/{}?token={}",
-            self.base_url, token_valid_seconds, self.connection_info.token
-        );
+        let request_url = format!("{}/key/{}", self.base_url, token_valid_seconds);
 
         let client = reqwest::Client::new();
 
-        client.post(request_url).send().await
+        let params = [("token", &self.connection_info.token)];
+
+        client.post(request_url).query(&params).send().await
     }
 
     /// Retrieve the info for a torrent.
@@ -82,10 +79,12 @@ impl Client {
     ///
     /// Will return an error if the HTTP request fails.
     pub async fn get_torrent_info(&self, info_hash: &str) -> Result<Response, Error> {
-        let request_url = format!("{}/torrent/{}?token={}", self.base_url, info_hash, self.connection_info.token);
+        let request_url = format!("{}/torrent/{}", self.base_url, info_hash);
 
         let client = reqwest::Client::new();
 
-        client.get(request_url).send().await
+        let params = [("token", &self.connection_info.token)];
+
+        client.get(request_url).query(&params).send().await
     }
 }

--- a/src/tracker/service.rs
+++ b/src/tracker/service.rs
@@ -184,7 +184,7 @@ async fn map_torrent_info_response(response: Response) -> Result<TorrentInfo, Se
         ServiceError::InternalServerError
     })?;
 
-    if body == *"torrent not known" {
+    if body == "\"torrent not known\"" {
         // todo: temporary fix. the service should return a 404 (StatusCode::NOT_FOUND).
         return Err(ServiceError::TorrentNotFound);
     }
@@ -209,7 +209,7 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_return_a_torrent_not_found_response_when_the_tracker_returns_the_current_torrent_not_known_response() {
-            let tracker_response = Response::new("torrent not known");
+            let tracker_response = Response::new("\"torrent not known\"");
 
             let result = map_torrent_info_response(tracker_response.into()).await.unwrap_err();
 


### PR DESCRIPTION
When the API token contains special characters like: `123g7#@agJtWFSgkdA5R$K22yeo$k6IhNq%T2$r`

The value must be URL-encoded like this:

http://tracker.torrust-demo.com:1212/v1/stats?token=123g7%23%40agJtWFSgkdA5R%24K22yeo%24k6IhNq%25T2%24r

Instead of using the token directly:

http://tracker.torrust-demo.com:1212/v1/stats?token=123g7#@agJtWFSgkdA5R$K22yeo$k6IhNq%T2$r

This PR also fixes the issue https://github.com/torrust/torrust-index/issues/391