### PR TITLE
Improve Tracker API errors log

### DIFF
--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -165,7 +165,7 @@ impl Index {
         {
             // If the torrent can't be whitelisted somehow, remove the torrent from database
             drop(self.torrent_repository.delete(&torrent_id).await);
-            return Err(e);
+            return Err(e.into());
         }
 
         // Build response
@@ -304,7 +304,8 @@ impl Index {
         self.torrent_repository.delete(&torrent_listing.torrent_id).await?;
 
         // Remove info-hash from tracker whitelist
-        let _ = self
+        // todo: handle the error when the tracker is offline or not well configured.
+        let _unused = self
             .tracker_service
             .remove_info_hash_from_whitelist(info_hash.to_string())
             .await;

--- a/src/tracker/service.rs
+++ b/src/tracker/service.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 
 use derive_more::{Display, Error};
 use hyper::StatusCode;
-use log::error;
-use reqwest::Response;
+use log::{debug, error};
 use serde::{Deserialize, Serialize};
 
 use super::api::{Client, ConnectionInfo};
@@ -18,14 +17,14 @@ pub enum TrackerAPIError {
     #[display(fmt = "Error with tracker connection.")]
     TrackerOffline,
 
-    #[display(fmt = "Could not whitelist torrent.")]
-    AddToWhitelistError,
+    #[display(fmt = "Invalid token for tracker API. Check the tracker token in settings.")]
+    InvalidToken,
 
-    #[display(fmt = "Could not remove torrent from whitelist.")]
-    RemoveFromWhitelistError,
+    #[display(fmt = "Tracker returned an internal server error.")]
+    InternalServerError,
 
-    #[display(fmt = "Could not retrieve a new user key.")]
-    RetrieveUserKeyError,
+    #[display(fmt = "Tracker returned an unexpected response status.")]
+    UnexpectedResponseStatus,
 
     #[display(fmt = "Could not save the newly generated user key into the database.")]
     CannotSaveUserKey,
@@ -98,14 +97,35 @@ impl Service {
     /// Will return an error if the HTTP request failed (for example if the
     /// tracker API is offline) or if the tracker API returned an error.
     pub async fn whitelist_info_hash(&self, info_hash: String) -> Result<(), TrackerAPIError> {
-        let response = self.api_client.whitelist_torrent(&info_hash).await;
+        debug!(target: "tracker-service", "add to whitelist: {info_hash}");
 
-        match response {
+        let maybe_response = self.api_client.whitelist_torrent(&info_hash).await;
+
+        debug!(target: "tracker-service", "add to whitelist response result: {:?}", maybe_response);
+
+        match maybe_response {
             Ok(response) => {
-                if response.status().is_success() {
-                    Ok(())
-                } else {
-                    Err(TrackerAPIError::AddToWhitelistError)
+                let status: StatusCode = response.status();
+
+                let body = response.text().await.map_err(|_| {
+                    error!(target: "tracker-service", "response without body");
+                    TrackerAPIError::MissingResponseBody
+                })?;
+
+                match status {
+                    StatusCode::OK => Ok(()),
+                    StatusCode::INTERNAL_SERVER_ERROR => {
+                        if body == "Unhandled rejection: Err { reason: \"token not valid\" }" {
+                            Err(TrackerAPIError::InvalidToken)
+                        } else {
+                            error!(target: "tracker-service", "add to whitelist 500 response: status {status}, body: {body}");
+                            Err(TrackerAPIError::InternalServerError)
+                        }
+                    }
+                    _ => {
+                        error!(target: "tracker-service", "add to whitelist unexpected response: status {status}, body: {body}");
+                        Err(TrackerAPIError::UnexpectedResponseStatus)
+                    }
                 }
             }
             Err(_) => Err(TrackerAPIError::TrackerOffline),
@@ -119,14 +139,35 @@ impl Service {
     /// Will return an error if the HTTP request failed (for example if the
     /// tracker API is offline) or if the tracker API returned an error.
     pub async fn remove_info_hash_from_whitelist(&self, info_hash: String) -> Result<(), TrackerAPIError> {
-        let response = self.api_client.remove_torrent_from_whitelist(&info_hash).await;
+        debug!(target: "tracker-service", "remove from whitelist: {info_hash}");
 
-        match response {
+        let maybe_response = self.api_client.remove_torrent_from_whitelist(&info_hash).await;
+
+        debug!(target: "tracker-service", "remove from whitelist response result: {:?}", maybe_response);
+
+        match maybe_response {
             Ok(response) => {
-                if response.status().is_success() {
-                    Ok(())
-                } else {
-                    Err(TrackerAPIError::RemoveFromWhitelistError)
+                let status: StatusCode = response.status();
+
+                let body = response.text().await.map_err(|_| {
+                    error!(target: "tracker-service", "response without body");
+                    TrackerAPIError::MissingResponseBody
+                })?;
+
+                match status {
+                    StatusCode::OK => Ok(()),
+                    StatusCode::INTERNAL_SERVER_ERROR => {
+                        if body == Self::invalid_token_body() {
+                            Err(TrackerAPIError::InvalidToken)
+                        } else {
+                            error!(target: "tracker-service", "remove from whitelist 500 response: status {status}, body: {body}");
+                            Err(TrackerAPIError::InternalServerError)
+                        }
+                    }
+                    _ => {
+                        error!(target: "tracker-service", "remove from whitelist unexpected response: status {status}, body: {body}");
+                        Err(TrackerAPIError::UnexpectedResponseStatus)
+                    }
                 }
             }
             Err(_) => Err(TrackerAPIError::TrackerOffline),
@@ -145,6 +186,8 @@ impl Service {
     /// Will return an error if the HTTP request to get generated a new
     /// user tracker key failed.
     pub async fn get_personal_announce_url(&self, user_id: UserId) -> Result<String, TrackerAPIError> {
+        debug!(target: "tracker-service", "get personal announce url for user: {user_id}");
+
         let tracker_key = self.database.get_user_tracker_key(user_id).await;
 
         match tracker_key {
@@ -163,14 +206,98 @@ impl Service {
     /// Will return an error if the HTTP request to get torrent info fails or
     /// if the response cannot be parsed.
     pub async fn get_torrent_info(&self, info_hash: &str) -> Result<TorrentInfo, TrackerAPIError> {
-        let response = self.api_client.get_torrent_info(info_hash).await;
+        debug!(target: "tracker-service", "get torrent info: {info_hash}");
 
-        match response {
+        let maybe_response = self.api_client.get_torrent_info(info_hash).await;
+
+        debug!(target: "tracker-service", "get torrent info response result: {:?}", maybe_response);
+
+        match maybe_response {
             Ok(response) => {
-                if response.status().is_success() {
-                    map_torrent_info_response(response).await
-                } else {
-                    Err(TrackerAPIError::RemoveFromWhitelistError)
+                let status: StatusCode = response.status();
+
+                let body = response.text().await.map_err(|_| {
+                    error!(target: "tracker-service", "response without body");
+                    TrackerAPIError::MissingResponseBody
+                })?;
+
+                match status {
+                    StatusCode::NOT_FOUND => Err(TrackerAPIError::TorrentNotFound),
+                    StatusCode::OK => {
+                        if body == Self::torrent_not_known_body() {
+                            // todo: temporary fix. the service should return a 404 (StatusCode::NOT_FOUND).
+                            return Err(TrackerAPIError::TorrentNotFound);
+                        }
+
+                        serde_json::from_str(&body).map_err(|e| {
+                            error!(
+                                target: "tracker-service", "Failed to parse torrent info from tracker response. Body: {}, Error: {}",
+                                body, e
+                            );
+                            TrackerAPIError::FailedToParseTrackerResponse { body }
+                        })
+                    }
+                    StatusCode::INTERNAL_SERVER_ERROR => {
+                        if body == Self::invalid_token_body() {
+                            Err(TrackerAPIError::InvalidToken)
+                        } else {
+                            error!(target: "tracker-service", "get torrent info 500 response: status {status}, body: {body}");
+                            Err(TrackerAPIError::InternalServerError)
+                        }
+                    }
+                    _ => {
+                        error!(target: "tracker-service", "get torrent info unhandled response: status {status}, body: {body}");
+                        Err(TrackerAPIError::UnexpectedResponseStatus)
+                    }
+                }
+            }
+            Err(_) => Err(TrackerAPIError::TrackerOffline),
+        }
+    }
+
+    /// Issue a new tracker key from tracker.
+    async fn retrieve_new_tracker_key(&self, user_id: i64) -> Result<TrackerKey, TrackerAPIError> {
+        debug!(target: "tracker-service", "retrieve key: {user_id}");
+
+        let maybe_response = self.api_client.retrieve_new_tracker_key(self.token_valid_seconds).await;
+
+        debug!(target: "tracker-service", "retrieve key response result: {:?}", maybe_response);
+
+        match maybe_response {
+            Ok(response) => {
+                let status: StatusCode = response.status();
+
+                let body = response.text().await.map_err(|_| {
+                    error!(target: "tracker-service", "response without body");
+                    TrackerAPIError::MissingResponseBody
+                })?;
+
+                match status {
+                    StatusCode::OK => {
+                        // Parse tracker key from response
+                        let tracker_key =
+                            serde_json::from_str(&body).map_err(|_| TrackerAPIError::FailedToParseTrackerResponse { body })?;
+
+                        // Add tracker key to database (tied to a user)
+                        self.database
+                            .add_tracker_key(user_id, &tracker_key)
+                            .await
+                            .map_err(|_| TrackerAPIError::CannotSaveUserKey)?;
+
+                        Ok(tracker_key)
+                    }
+                    StatusCode::INTERNAL_SERVER_ERROR => {
+                        if body == Self::invalid_token_body() {
+                            Err(TrackerAPIError::InvalidToken)
+                        } else {
+                            error!(target: "tracker-service", "retrieve key 500 response: status {status}, body: {body}");
+                            Err(TrackerAPIError::InternalServerError)
+                        }
+                    }
+                    _ => {
+                        error!(target: "tracker-service", " retrieve key unexpected response: status {status}, body: {body}");
+                        Err(TrackerAPIError::UnexpectedResponseStatus)
+                    }
                 }
             }
             Err(_) => Err(TrackerAPIError::TrackerOffline),
@@ -183,137 +310,11 @@ impl Service {
         format!("{}/{}", self.tracker_url, tracker_key.key)
     }
 
-    /// Issue a new tracker key from tracker.
-    async fn retrieve_new_tracker_key(&self, user_id: i64) -> Result<TrackerKey, TrackerAPIError> {
-        let response = self.api_client.retrieve_new_tracker_key(self.token_valid_seconds).await;
-
-        match response {
-            Ok(response) => {
-                if response.status().is_success() {
-                    let body = response.text().await.map_err(|_| {
-                        error!("Tracker API response without body");
-                        TrackerAPIError::MissingResponseBody
-                    })?;
-
-                    // Parse tracker key from response
-                    let tracker_key =
-                        serde_json::from_str(&body).map_err(|_| TrackerAPIError::FailedToParseTrackerResponse { body })?;
-
-                    // Add tracker key to database (tied to a user)
-                    self.database
-                        .add_tracker_key(user_id, &tracker_key)
-                        .await
-                        .map_err(|_| TrackerAPIError::CannotSaveUserKey)?;
-
-                    Ok(tracker_key)
-                } else {
-                    Err(TrackerAPIError::RetrieveUserKeyError)
-                }
-            }
-            Err(_) => Err(TrackerAPIError::TrackerOffline),
-        }
-    }
-}
-
-async fn map_torrent_info_response(response: Response) -> Result<TorrentInfo, TrackerAPIError> {
-    if response.status() == StatusCode::NOT_FOUND {
-        return Err(TrackerAPIError::TorrentNotFound);
+    fn invalid_token_body() -> String {
+        "Unhandled rejection: Err { reason: \"token not valid\" }".to_string()
     }
 
-    let body = response.text().await.map_err(|_| {
-        error!("Tracker API response without body");
-        TrackerAPIError::MissingResponseBody
-    })?;
-
-    if body == "\"torrent not known\"" {
-        // todo: temporary fix. the service should return a 404 (StatusCode::NOT_FOUND).
-        return Err(TrackerAPIError::TorrentNotFound);
-    }
-
-    serde_json::from_str(&body).map_err(|e| {
-        error!(
-            "Failed to parse torrent info from tracker response. Body: {}, Error: {}",
-            body, e
-        );
-        TrackerAPIError::FailedToParseTrackerResponse { body }
-    })
-}
-
-#[cfg(test)]
-mod tests {
-
-    mod getting_the_torrent_info_from_the_tracker {
-        use hyper::{Response, StatusCode};
-
-        use crate::tracker::service::{map_torrent_info_response, TorrentInfo, TrackerAPIError};
-
-        #[tokio::test]
-        async fn it_should_return_a_torrent_not_found_response_when_the_tracker_returns_the_current_torrent_not_known_response() {
-            let tracker_response = Response::new("\"torrent not known\"");
-
-            let result = map_torrent_info_response(tracker_response.into()).await.unwrap_err();
-
-            assert_eq!(result, TrackerAPIError::TorrentNotFound);
-        }
-
-        #[tokio::test]
-        async fn it_should_return_a_torrent_not_found_response_when_the_tracker_returns_the_future_torrent_not_known_response() {
-            // In the future the tracker should return a 4040 response.
-            // See: https://github.com/torrust/torrust-tracker/issues/144
-
-            let tracker_response = Response::builder().status(StatusCode::NOT_FOUND).body("").unwrap();
-
-            let result = map_torrent_info_response(tracker_response.into()).await.unwrap_err();
-
-            assert_eq!(result, TrackerAPIError::TorrentNotFound);
-        }
-
-        #[tokio::test]
-        async fn it_should_return_the_torrent_info_when_the_tracker_returns_the_torrent_info() {
-            let body = r#"
-                {
-                    "info_hash": "4f2ae7294f2c4865c38565f92a077d1591a0dd41",
-                    "seeders": 0,
-                    "completed": 0,
-                    "leechers": 0,
-                    "peers": []
-                }
-            "#;
-
-            let tracker_response = Response::new(body);
-
-            let torrent_info = map_torrent_info_response(tracker_response.into()).await.unwrap();
-
-            assert_eq!(
-                torrent_info,
-                TorrentInfo {
-                    info_hash: "4f2ae7294f2c4865c38565f92a077d1591a0dd41".to_string(),
-                    seeders: 0,
-                    completed: 0,
-                    leechers: 0,
-                    peers: vec![]
-                }
-            );
-        }
-
-        #[tokio::test]
-        async fn it_should_return_an_internal_server_error_when_the_tracker_response_cannot_be_parsed() {
-            let invalid_json_body_for_torrent_info = r#"
-                {
-                    "field": "value"
-                }
-            "#;
-
-            let tracker_response = Response::new(invalid_json_body_for_torrent_info);
-
-            let err = map_torrent_info_response(tracker_response.into()).await.unwrap_err();
-
-            assert_eq!(
-                err,
-                TrackerAPIError::FailedToParseTrackerResponse {
-                    body: invalid_json_body_for_torrent_info.to_string()
-                }
-            );
-        }
+    fn torrent_not_known_body() -> String {
+        "\"torrent not known\"".to_string()
     }
 }

--- a/src/tracker/statistics_importer.rs
+++ b/src/tracker/statistics_importer.rs
@@ -39,11 +39,13 @@ impl StatisticsImporter {
             let ret = self.import_torrent_statistics(torrent.torrent_id, &torrent.info_hash).await;
 
             if let Some(err) = ret.err() {
-                let message = format!(
-                    "Error updating torrent tracker stats for torrent with id {}: {:?}",
-                    torrent.torrent_id, err
-                );
-                error!(target: "statistics_importer", "{}", message);
+                if err != TrackerAPIError::TorrentNotFound {
+                    let message = format!(
+                        "Error updating torrent tracker stats for torrent. Torrent: id {}; infohash {}. Error: {:?}",
+                        torrent.torrent_id, torrent.info_hash, err
+                    );
+                    error!(target: "statistics_importer", "{}", message);
+                }
             }
         }
 

--- a/tests/common/contexts/torrent/responses.rs
+++ b/tests/common/contexts/torrent/responses.rs
@@ -74,17 +74,9 @@ pub struct TorrentDetails {
     pub encoding: Option<String>,
 }
 
-#[rustversion::stable]
-#[derive(Deserialize, PartialEq, Debug)]
-pub struct Category {
-    pub category_id: CategoryId, // todo: rename to `id`
-    pub name: String,
-    pub num_torrents: u64,
-}
-
-#[rustversion::nightly]
-#[derive(Deserialize, PartialEq, Debug)]
+#[allow(unknown_lints)]
 #[allow(clippy::struct_field_names)]
+#[derive(Deserialize, PartialEq, Debug)]
 pub struct Category {
     pub category_id: CategoryId, // todo: rename to `id`
     pub name: String,


### PR DESCRIPTION
We need the specific error requesting the tracker API to include the error in the logs.

- [x] Refactor to decouple API errors from app errors.
- [x] Change the statistic importer log to include the exact error from the tracker API.
- [x] When we import statistics from the tracker, don't log an error when the torrent is not found. It could have been removed because there are no peers.