### PR TITLE
Add timeout to `health_check` binary

### DIFF
--- a/src/bin/health_check.rs
+++ b/src/bin/health_check.rs
@@ -4,14 +4,17 @@
 //!
 //! - They are harder to maintain.
 //! - They introduce new attack vectors.
+use std::time::Duration;
 use std::{env, process};
+
+use reqwest::Client;
 
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
         eprintln!("Usage:   cargo run --bin health_check <HEALTH_URL>");
-        eprintln!("Example: cargo run --bin health_check http://localhost:3002/health_check");
+        eprintln!("Example: cargo run --bin health_check http://127.0.0.1:3001/health_check");
         std::process::exit(1);
     }
 
@@ -19,7 +22,9 @@ async fn main() {
 
     let url = &args[1].clone();
 
-    match reqwest::get(url).await {
+    let client = Client::builder().timeout(Duration::from_secs(5)).build().unwrap();
+
+    match client.get(url).send().await {
         Ok(response) => {
             if response.status().is_success() {
                 println!("STATUS: {}", response.status());


### PR DESCRIPTION
Add timeout to `health_check` binary.

```console
cargo run --bin health_check http://127.0.0.1:3001/health_check
```

That command now fails if it does not get a response in 5 seconds.