### PR TITLE
Index API client: add timeout to requests

### DIFF
--- a/src/console/commands/seeder/api.rs
+++ b/src/console/commands/seeder/api.rs
@@ -35,6 +35,9 @@ pub async fn upload_torrent(client: &Client, upload_torrent_form: UploadTorrentM
         add_category(client, &upload_torrent_form.category).await;
     }
 
+    // todo: if we receive timeout error we should retry later. Otherwise we
+    // have to restart the seeder manually.
+
     let response = client
         .upload_torrent(upload_torrent_form.into())
         .await

--- a/src/console/commands/seeder/api.rs
+++ b/src/console/commands/seeder/api.rs
@@ -35,7 +35,10 @@ pub async fn upload_torrent(client: &Client, upload_torrent_form: UploadTorrentM
         add_category(client, &upload_torrent_form.category).await;
     }
 
-    let response = client.upload_torrent(upload_torrent_form.into()).await;
+    let response = client
+        .upload_torrent(upload_torrent_form.into())
+        .await
+        .expect("API should return a response");
 
     debug!(target:"seeder", "response: {}", response.status);
 
@@ -68,7 +71,8 @@ pub async fn login(client: &Client, username: &str, password: &str) -> LoggedInU
             login: username.to_owned(),
             password: password.to_owned(),
         })
-        .await;
+        .await
+        .expect("API should return a response");
 
     let res: SuccessfulLoginResponse = serde_json::from_str(&response.body).unwrap_or_else(|_| {
         panic!(
@@ -86,7 +90,7 @@ pub async fn login(client: &Client, username: &str, password: &str) -> LoggedInU
 ///
 /// Panics if the response body is not a valid JSON.
 pub async fn get_categories(client: &Client) -> Vec<ListItem> {
-    let response = client.get_categories().await;
+    let response = client.get_categories().await.expect("API should return a response");
 
     let res: ListResponse = serde_json::from_str(&response.body).unwrap();
 
@@ -94,6 +98,10 @@ pub async fn get_categories(client: &Client) -> Vec<ListItem> {
 }
 
 /// It adds a new category.
+///
+/// # Panics
+///
+/// Will panic if it doesn't get a response form the API.
 pub async fn add_category(client: &Client, name: &str) -> TextResponse {
     client
         .add_category(AddCategoryForm {
@@ -101,6 +109,7 @@ pub async fn add_category(client: &Client, name: &str) -> TextResponse {
             icon: None,
         })
         .await
+        .expect("API should return a response")
 }
 
 /// It checks if the category list contains the given category.

--- a/src/web/api/client/v1/client.rs
+++ b/src/web/api/client/v1/client.rs
@@ -15,8 +15,6 @@ pub struct Client {
 }
 
 impl Client {
-    // todo: forms in POST requests can be passed by reference.
-
     fn base_path() -> String {
         "/v1".to_string()
     }

--- a/src/web/api/client/v1/client.rs
+++ b/src/web/api/client/v1/client.rs
@@ -9,6 +9,17 @@ use super::contexts::user::forms::{LoginForm, RegistrationForm, TokenRenewalForm
 use super::http::{Http, Query};
 use super::responses::{self, TextResponse};
 
+#[derive(Debug)]
+pub enum Error {
+    HttpError(reqwest::Error),
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Error::HttpError(err)
+    }
+}
+
 /// API Client
 pub struct Client {
     http_client: Http,
@@ -44,197 +55,228 @@ impl Client {
 
     // Context: about
 
-    /// # Panics
+    /// # Errors
     ///
     /// Will panic if the request fails.
-    pub async fn about(&self) -> TextResponse {
-        self.http_client.get("/about", Query::empty()).await.unwrap()
+    pub async fn about(&self) -> Result<TextResponse, Error> {
+        self.http_client.get("/about", Query::empty()).await.map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.    
-    pub async fn license(&self) -> TextResponse {
-        self.http_client.get("/about/license", Query::empty()).await.unwrap()
+    /// Will panic if the request fails.  
+    pub async fn license(&self) -> Result<TextResponse, Error> {
+        self.http_client
+            .get("/about/license", Query::empty())
+            .await
+            .map_err(Error::from)
     }
 
     // Context: category
 
-    /// # Panics
+    /// # Errors
     ///
     /// Will panic if the request fails.
-    pub async fn get_categories(&self) -> TextResponse {
-        self.http_client.get("/category", Query::empty()).await.unwrap()
+    pub async fn get_categories(&self) -> Result<TextResponse, Error> {
+        self.http_client.get("/category", Query::empty()).await.map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
     /// Will panic if the request fails.
-    pub async fn add_category(&self, add_category_form: AddCategoryForm) -> TextResponse {
-        self.http_client.post("/category", &add_category_form).await.unwrap()
+    pub async fn add_category(&self, add_category_form: AddCategoryForm) -> Result<TextResponse, Error> {
+        self.http_client
+            .post("/category", &add_category_form)
+            .await
+            .map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
     /// Will panic if the request fails.
-    pub async fn delete_category(&self, delete_category_form: DeleteCategoryForm) -> TextResponse {
+    pub async fn delete_category(&self, delete_category_form: DeleteCategoryForm) -> Result<TextResponse, Error> {
         self.http_client
             .delete_with_body("/category", &delete_category_form)
             .await
-            .unwrap()
+            .map_err(Error::from)
     }
 
     // Context: tag
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.    
-    pub async fn get_tags(&self) -> TextResponse {
-        self.http_client.get("/tags", Query::empty()).await.unwrap()
+    /// Will panic if the request fails.  
+    pub async fn get_tags(&self) -> Result<TextResponse, Error> {
+        self.http_client.get("/tags", Query::empty()).await.map_err(Error::from)
     }
 
-    /// # Panics
-    ///
-    /// Will panic if the request fails.       
-    pub async fn add_tag(&self, add_tag_form: AddTagForm) -> TextResponse {
-        self.http_client.post("/tag", &add_tag_form).await.unwrap()
-    }
-
-    /// # Panics
+    /// # Errors
     ///
     /// Will panic if the request fails.   
-    pub async fn delete_tag(&self, delete_tag_form: DeleteTagForm) -> TextResponse {
-        self.http_client.delete_with_body("/tag", &delete_tag_form).await.unwrap()
+    pub async fn add_tag(&self, add_tag_form: AddTagForm) -> Result<TextResponse, Error> {
+        self.http_client.post("/tag", &add_tag_form).await.map_err(Error::from)
+    }
+
+    /// # Errors
+    ///
+    /// Will panic if the request fails.
+    pub async fn delete_tag(&self, delete_tag_form: DeleteTagForm) -> Result<TextResponse, Error> {
+        self.http_client
+            .delete_with_body("/tag", &delete_tag_form)
+            .await
+            .map_err(Error::from)
     }
 
     // Context: root
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.    
-    pub async fn root(&self) -> TextResponse {
-        self.http_client.get("", Query::empty()).await.unwrap()
+    /// Will panic if the request fails.   
+    pub async fn root(&self) -> Result<TextResponse, Error> {
+        self.http_client.get("", Query::empty()).await.map_err(Error::from)
     }
 
     // Context: settings
 
-    /// # Panics
-    ///
-    /// Will panic if the request fails.    
-    pub async fn get_public_settings(&self) -> TextResponse {
-        self.http_client.get("/settings/public", Query::empty()).await.unwrap()
-    }
-
-    /// # Panics
+    /// # Errors
     ///
     /// Will panic if the request fails.
-    pub async fn get_site_name(&self) -> TextResponse {
-        self.http_client.get("/settings/name", Query::empty()).await.unwrap()
+    pub async fn get_public_settings(&self) -> Result<TextResponse, Error> {
+        self.http_client
+            .get("/settings/public", Query::empty())
+            .await
+            .map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
     /// Will panic if the request fails.
-    pub async fn get_settings(&self) -> TextResponse {
-        self.http_client.get("/settings", Query::empty()).await.unwrap()
+    pub async fn get_site_name(&self) -> Result<TextResponse, Error> {
+        self.http_client
+            .get("/settings/name", Query::empty())
+            .await
+            .map_err(Error::from)
+    }
+
+    /// # Errors
+    ///
+    /// Will panic if the request fails.
+    pub async fn get_settings(&self) -> Result<TextResponse, Error> {
+        self.http_client.get("/settings", Query::empty()).await.map_err(Error::from)
     }
 
     // Context: torrent
 
-    /// # Panics
+    /// # Errors
     ///
     /// Will panic if the request fails.
-    pub async fn get_torrents(&self, params: Query) -> TextResponse {
-        self.http_client.get("/torrents", params).await.unwrap()
+    pub async fn get_torrents(&self, params: Query) -> Result<TextResponse, Error> {
+        self.http_client.get("/torrents", params).await.map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.    
-    pub async fn get_torrent(&self, info_hash: &InfoHash) -> TextResponse {
+    /// Will panic if the request fails.  
+    pub async fn get_torrent(&self, info_hash: &InfoHash) -> Result<TextResponse, Error> {
         self.http_client
             .get(&format!("/torrent/{info_hash}"), Query::empty())
             .await
-            .unwrap()
+            .map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.   
-    pub async fn delete_torrent(&self, info_hash: &InfoHash) -> TextResponse {
-        self.http_client.delete(&format!("/torrent/{info_hash}")).await.unwrap()
+    /// Will panic if the request fails.
+    pub async fn delete_torrent(&self, info_hash: &InfoHash) -> Result<TextResponse, Error> {
+        self.http_client
+            .delete(&format!("/torrent/{info_hash}"))
+            .await
+            .map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.   
-    pub async fn update_torrent(&self, info_hash: &InfoHash, update_torrent_form: UpdateTorrentForm) -> TextResponse {
+    /// Will panic if the request fails.
+    pub async fn update_torrent(
+        &self,
+        info_hash: &InfoHash,
+        update_torrent_form: UpdateTorrentForm,
+    ) -> Result<TextResponse, Error> {
         self.http_client
             .put(&format!("/torrent/{info_hash}"), &update_torrent_form)
             .await
-            .unwrap()
+            .map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.   
-    pub async fn upload_torrent(&self, form: multipart::Form) -> TextResponse {
-        self.http_client.post_multipart("/torrent/upload", form).await.unwrap()
+    /// Will panic if the request fails.
+    pub async fn upload_torrent(&self, form: multipart::Form) -> Result<TextResponse, Error> {
+        self.http_client
+            .post_multipart("/torrent/upload", form)
+            .await
+            .map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.   
-    pub async fn download_torrent(&self, info_hash: &InfoHash) -> responses::BinaryResponse {
+    /// Will panic if the request fails.
+    pub async fn download_torrent(&self, info_hash: &InfoHash) -> Result<responses::BinaryResponse, Error> {
         self.http_client
             .get_binary(&format!("/torrent/download/{info_hash}"), Query::empty())
             .await
-            .unwrap()
+            .map_err(Error::from)
     }
 
     // Context: user
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.   
-    pub async fn register_user(&self, registration_form: RegistrationForm) -> TextResponse {
-        self.http_client.post("/user/register", &registration_form).await.unwrap()
+    /// Will panic if the request fails.
+    pub async fn register_user(&self, registration_form: RegistrationForm) -> Result<TextResponse, Error> {
+        self.http_client
+            .post("/user/register", &registration_form)
+            .await
+            .map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.   
-    pub async fn login_user(&self, registration_form: LoginForm) -> TextResponse {
-        self.http_client.post("/user/login", &registration_form).await.unwrap()
+    /// Will panic if the request fails.
+    pub async fn login_user(&self, registration_form: LoginForm) -> Result<TextResponse, Error> {
+        self.http_client
+            .post("/user/login", &registration_form)
+            .await
+            .map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.   
-    pub async fn verify_token(&self, token_verification_form: TokenVerificationForm) -> TextResponse {
+    /// Will panic if the request fails.
+    pub async fn verify_token(&self, token_verification_form: TokenVerificationForm) -> Result<TextResponse, Error> {
         self.http_client
             .post("/user/token/verify", &token_verification_form)
             .await
-            .unwrap()
+            .map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.   
-    pub async fn renew_token(&self, token_verification_form: TokenRenewalForm) -> TextResponse {
+    /// Will panic if the request fails.
+    pub async fn renew_token(&self, token_verification_form: TokenRenewalForm) -> Result<TextResponse, Error> {
         self.http_client
             .post("/user/token/renew", &token_verification_form)
             .await
-            .unwrap()
+            .map_err(Error::from)
     }
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the request fails.   
-    pub async fn ban_user(&self, username: Username) -> TextResponse {
+    /// Will panic if the request fails.
+    pub async fn ban_user(&self, username: Username) -> Result<TextResponse, Error> {
         self.http_client
             .delete(&format!("/user/ban/{}", &username.value))
             .await
-            .unwrap()
+            .map_err(Error::from)
     }
 }

--- a/src/web/api/client/v1/client.rs
+++ b/src/web/api/client/v1/client.rs
@@ -92,8 +92,6 @@ impl Client {
     ///
     /// Will panic if the request fails.    
     pub async fn get_tags(&self) -> TextResponse {
-        // code-review: some endpoint are using plural
-        // (for instance, `get_categories`) and some singular.
         self.http_client.get("/tags", Query::empty()).await.unwrap()
     }
 

--- a/src/web/api/client/v1/client.rs
+++ b/src/web/api/client/v1/client.rs
@@ -46,113 +46,199 @@ impl Client {
 
     // Context: about
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.
     pub async fn about(&self) -> TextResponse {
-        self.http_client.get("/about", Query::empty()).await
+        self.http_client.get("/about", Query::empty()).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.    
     pub async fn license(&self) -> TextResponse {
-        self.http_client.get("/about/license", Query::empty()).await
+        self.http_client.get("/about/license", Query::empty()).await.unwrap()
     }
 
     // Context: category
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.
     pub async fn get_categories(&self) -> TextResponse {
-        self.http_client.get("/category", Query::empty()).await
+        self.http_client.get("/category", Query::empty()).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.
     pub async fn add_category(&self, add_category_form: AddCategoryForm) -> TextResponse {
-        self.http_client.post("/category", &add_category_form).await
+        self.http_client.post("/category", &add_category_form).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.
     pub async fn delete_category(&self, delete_category_form: DeleteCategoryForm) -> TextResponse {
-        self.http_client.delete_with_body("/category", &delete_category_form).await
+        self.http_client
+            .delete_with_body("/category", &delete_category_form)
+            .await
+            .unwrap()
     }
 
     // Context: tag
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.    
     pub async fn get_tags(&self) -> TextResponse {
         // code-review: some endpoint are using plural
         // (for instance, `get_categories`) and some singular.
-        self.http_client.get("/tags", Query::empty()).await
+        self.http_client.get("/tags", Query::empty()).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.       
     pub async fn add_tag(&self, add_tag_form: AddTagForm) -> TextResponse {
-        self.http_client.post("/tag", &add_tag_form).await
+        self.http_client.post("/tag", &add_tag_form).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.   
     pub async fn delete_tag(&self, delete_tag_form: DeleteTagForm) -> TextResponse {
-        self.http_client.delete_with_body("/tag", &delete_tag_form).await
+        self.http_client.delete_with_body("/tag", &delete_tag_form).await.unwrap()
     }
 
     // Context: root
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.    
     pub async fn root(&self) -> TextResponse {
-        self.http_client.get("", Query::empty()).await
+        self.http_client.get("", Query::empty()).await.unwrap()
     }
 
     // Context: settings
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.    
     pub async fn get_public_settings(&self) -> TextResponse {
-        self.http_client.get("/settings/public", Query::empty()).await
+        self.http_client.get("/settings/public", Query::empty()).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.
     pub async fn get_site_name(&self) -> TextResponse {
-        self.http_client.get("/settings/name", Query::empty()).await
+        self.http_client.get("/settings/name", Query::empty()).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.
     pub async fn get_settings(&self) -> TextResponse {
-        self.http_client.get("/settings", Query::empty()).await
+        self.http_client.get("/settings", Query::empty()).await.unwrap()
     }
 
     // Context: torrent
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.
     pub async fn get_torrents(&self, params: Query) -> TextResponse {
-        self.http_client.get("/torrents", params).await
+        self.http_client.get("/torrents", params).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.    
     pub async fn get_torrent(&self, info_hash: &InfoHash) -> TextResponse {
-        self.http_client.get(&format!("/torrent/{info_hash}"), Query::empty()).await
+        self.http_client
+            .get(&format!("/torrent/{info_hash}"), Query::empty())
+            .await
+            .unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.   
     pub async fn delete_torrent(&self, info_hash: &InfoHash) -> TextResponse {
-        self.http_client.delete(&format!("/torrent/{info_hash}")).await
+        self.http_client.delete(&format!("/torrent/{info_hash}")).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.   
     pub async fn update_torrent(&self, info_hash: &InfoHash, update_torrent_form: UpdateTorrentForm) -> TextResponse {
         self.http_client
             .put(&format!("/torrent/{info_hash}"), &update_torrent_form)
             .await
+            .unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.   
     pub async fn upload_torrent(&self, form: multipart::Form) -> TextResponse {
-        self.http_client.post_multipart("/torrent/upload", form).await
+        self.http_client.post_multipart("/torrent/upload", form).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.   
     pub async fn download_torrent(&self, info_hash: &InfoHash) -> responses::BinaryResponse {
         self.http_client
             .get_binary(&format!("/torrent/download/{info_hash}"), Query::empty())
             .await
+            .unwrap()
     }
 
     // Context: user
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.   
     pub async fn register_user(&self, registration_form: RegistrationForm) -> TextResponse {
-        self.http_client.post("/user/register", &registration_form).await
+        self.http_client.post("/user/register", &registration_form).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.   
     pub async fn login_user(&self, registration_form: LoginForm) -> TextResponse {
-        self.http_client.post("/user/login", &registration_form).await
+        self.http_client.post("/user/login", &registration_form).await.unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.   
     pub async fn verify_token(&self, token_verification_form: TokenVerificationForm) -> TextResponse {
-        self.http_client.post("/user/token/verify", &token_verification_form).await
+        self.http_client
+            .post("/user/token/verify", &token_verification_form)
+            .await
+            .unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.   
     pub async fn renew_token(&self, token_verification_form: TokenRenewalForm) -> TextResponse {
-        self.http_client.post("/user/token/renew", &token_verification_form).await
+        self.http_client
+            .post("/user/token/renew", &token_verification_form)
+            .await
+            .unwrap()
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the request fails.   
     pub async fn ban_user(&self, username: Username) -> TextResponse {
-        self.http_client.delete(&format!("/user/ban/{}", &username.value)).await
+        self.http_client
+            .delete(&format!("/user/ban/{}", &username.value))
+            .await
+            .unwrap()
     }
 }

--- a/src/web/api/client/v1/client.rs
+++ b/src/web/api/client/v1/client.rs
@@ -57,14 +57,14 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn about(&self) -> Result<TextResponse, Error> {
         self.http_client.get("/about", Query::empty()).await.map_err(Error::from)
     }
 
     /// # Errors
     ///
-    /// Will panic if the request fails.  
+    /// Will return an error if the request fails.  
     pub async fn license(&self) -> Result<TextResponse, Error> {
         self.http_client
             .get("/about/license", Query::empty())
@@ -76,14 +76,14 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn get_categories(&self) -> Result<TextResponse, Error> {
         self.http_client.get("/category", Query::empty()).await.map_err(Error::from)
     }
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn add_category(&self, add_category_form: AddCategoryForm) -> Result<TextResponse, Error> {
         self.http_client
             .post("/category", &add_category_form)
@@ -93,7 +93,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn delete_category(&self, delete_category_form: DeleteCategoryForm) -> Result<TextResponse, Error> {
         self.http_client
             .delete_with_body("/category", &delete_category_form)
@@ -105,21 +105,21 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.  
+    /// Will return an error if the request fails.  
     pub async fn get_tags(&self) -> Result<TextResponse, Error> {
         self.http_client.get("/tags", Query::empty()).await.map_err(Error::from)
     }
 
     /// # Errors
     ///
-    /// Will panic if the request fails.   
+    /// Will return an error if the request fails.   
     pub async fn add_tag(&self, add_tag_form: AddTagForm) -> Result<TextResponse, Error> {
         self.http_client.post("/tag", &add_tag_form).await.map_err(Error::from)
     }
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn delete_tag(&self, delete_tag_form: DeleteTagForm) -> Result<TextResponse, Error> {
         self.http_client
             .delete_with_body("/tag", &delete_tag_form)
@@ -131,7 +131,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.   
+    /// Will return an error if the request fails.   
     pub async fn root(&self) -> Result<TextResponse, Error> {
         self.http_client.get("", Query::empty()).await.map_err(Error::from)
     }
@@ -140,7 +140,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn get_public_settings(&self) -> Result<TextResponse, Error> {
         self.http_client
             .get("/settings/public", Query::empty())
@@ -150,7 +150,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn get_site_name(&self) -> Result<TextResponse, Error> {
         self.http_client
             .get("/settings/name", Query::empty())
@@ -160,7 +160,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn get_settings(&self) -> Result<TextResponse, Error> {
         self.http_client.get("/settings", Query::empty()).await.map_err(Error::from)
     }
@@ -169,14 +169,14 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn get_torrents(&self, params: Query) -> Result<TextResponse, Error> {
         self.http_client.get("/torrents", params).await.map_err(Error::from)
     }
 
     /// # Errors
     ///
-    /// Will panic if the request fails.  
+    /// Will return an error if the request fails.  
     pub async fn get_torrent(&self, info_hash: &InfoHash) -> Result<TextResponse, Error> {
         self.http_client
             .get(&format!("/torrent/{info_hash}"), Query::empty())
@@ -186,7 +186,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn delete_torrent(&self, info_hash: &InfoHash) -> Result<TextResponse, Error> {
         self.http_client
             .delete(&format!("/torrent/{info_hash}"))
@@ -196,7 +196,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn update_torrent(
         &self,
         info_hash: &InfoHash,
@@ -210,7 +210,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn upload_torrent(&self, form: multipart::Form) -> Result<TextResponse, Error> {
         self.http_client
             .post_multipart("/torrent/upload", form)
@@ -220,7 +220,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn download_torrent(&self, info_hash: &InfoHash) -> Result<responses::BinaryResponse, Error> {
         self.http_client
             .get_binary(&format!("/torrent/download/{info_hash}"), Query::empty())
@@ -232,7 +232,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn register_user(&self, registration_form: RegistrationForm) -> Result<TextResponse, Error> {
         self.http_client
             .post("/user/register", &registration_form)
@@ -242,7 +242,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn login_user(&self, registration_form: LoginForm) -> Result<TextResponse, Error> {
         self.http_client
             .post("/user/login", &registration_form)
@@ -252,7 +252,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn verify_token(&self, token_verification_form: TokenVerificationForm) -> Result<TextResponse, Error> {
         self.http_client
             .post("/user/token/verify", &token_verification_form)
@@ -262,7 +262,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn renew_token(&self, token_verification_form: TokenRenewalForm) -> Result<TextResponse, Error> {
         self.http_client
             .post("/user/token/renew", &token_verification_form)
@@ -272,7 +272,7 @@ impl Client {
 
     /// # Errors
     ///
-    /// Will panic if the request fails.
+    /// Will return an error if the request fails.
     pub async fn ban_user(&self, username: Username) -> Result<TextResponse, Error> {
         self.http_client
             .delete(&format!("/user/ban/{}", &username.value))

--- a/src/web/api/client/v1/client.rs
+++ b/src/web/api/client/v1/client.rs
@@ -1,4 +1,4 @@
-use reqwest::multipart;
+use reqwest::{multipart, Url};
 
 use super::connection_info::ConnectionInfo;
 use super::contexts::category::forms::{AddCategoryForm, DeleteCategoryForm};
@@ -22,13 +22,13 @@ impl Client {
     }
 
     #[must_use]
-    pub fn unauthenticated(bind_address: &str) -> Self {
-        Self::new(ConnectionInfo::anonymous(bind_address, &Self::base_path()))
+    pub fn unauthenticated(base_url: &Url) -> Self {
+        Self::new(ConnectionInfo::anonymous(base_url, &Self::base_path()))
     }
 
     #[must_use]
-    pub fn authenticated(bind_address: &str, token: &str) -> Self {
-        Self::new(ConnectionInfo::new(bind_address, &Self::base_path(), token))
+    pub fn authenticated(base_url: &Url, token: &str) -> Self {
+        Self::new(ConnectionInfo::new(base_url, &Self::base_path(), token))
     }
 
     #[must_use]

--- a/src/web/api/client/v1/connection_info.rs
+++ b/src/web/api/client/v1/connection_info.rs
@@ -1,4 +1,5 @@
-use std::{fmt, str::FromStr};
+use std::fmt;
+use std::str::FromStr;
 
 use reqwest::Url;
 

--- a/src/web/api/client/v1/connection_info.rs
+++ b/src/web/api/client/v1/connection_info.rs
@@ -1,24 +1,70 @@
+use std::{fmt, str::FromStr};
+
+use reqwest::Url;
+
+#[derive(Clone)]
+pub enum Scheme {
+    Http,
+    Https,
+}
+
+impl fmt::Display for Scheme {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Scheme::Http => write!(f, "http"),
+            Scheme::Https => write!(f, "https"),
+        }
+    }
+}
+
+impl FromStr for Scheme {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "http" => Ok(Scheme::Http),
+            "https" => Ok(Scheme::Https),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct ConnectionInfo {
+    pub scheme: Scheme,
     pub bind_address: String,
     pub base_path: String,
     pub token: Option<String>,
 }
 
 impl ConnectionInfo {
+    /// # Panics
+    ///
+    /// Will panic if the the base URL does not have a valid scheme: `http` or `https`.
     #[must_use]
-    pub fn new(bind_address: &str, base_path: &str, token: &str) -> Self {
+    pub fn new(base_url: &Url, base_path: &str, token: &str) -> Self {
         Self {
-            bind_address: bind_address.to_string(),
+            scheme: base_url
+                .scheme()
+                .parse()
+                .expect("base API URL scheme should be 'http' or 'https"),
+            bind_address: base_url.authority().to_string(),
             base_path: base_path.to_string(),
             token: Some(token.to_string()),
         }
     }
 
+    /// # Panics
+    ///
+    /// Will panic if the the base URL does not have a valid scheme: `http` or `https`.    
     #[must_use]
-    pub fn anonymous(bind_address: &str, base_path: &str) -> Self {
+    pub fn anonymous(base_url: &Url, base_path: &str) -> Self {
         Self {
-            bind_address: bind_address.to_string(),
+            scheme: base_url
+                .scheme()
+                .parse()
+                .expect("base API URL scheme should be 'http' or 'https"),
+            bind_address: base_url.authority().to_string(),
             base_path: base_path.to_string(),
             token: None,
         }

--- a/src/web/api/client/v1/http.rs
+++ b/src/web/api/client/v1/http.rs
@@ -267,8 +267,8 @@ impl Http {
 
     fn base_url(&self, path: &str) -> String {
         format!(
-            "http://{}{}{path}",
-            &self.connection_info.bind_address, &self.connection_info.base_path
+            "{}://{}{}{path}",
+            &self.connection_info.scheme, &self.connection_info.bind_address, &self.connection_info.base_path
         )
     }
 }

--- a/src/web/api/client/v1/http.rs
+++ b/src/web/api/client/v1/http.rs
@@ -1,3 +1,9 @@
+use reqwest::multipart;
+use serde::Serialize;
+
+use super::connection_info::ConnectionInfo;
+use super::responses::{BinaryResponse, TextResponse};
+
 pub type ReqwestQuery = Vec<ReqwestQueryParam>;
 pub type ReqwestQueryParam = (String, String);
 
@@ -53,5 +59,216 @@ impl QueryParam {
 impl From<QueryParam> for ReqwestQueryParam {
     fn from(param: QueryParam) -> Self {
         (param.name, param.value)
+    }
+}
+
+/// Generic HTTP Client
+pub struct Http {
+    connection_info: ConnectionInfo,
+}
+
+impl Http {
+    #[must_use]
+    pub fn new(connection_info: ConnectionInfo) -> Self {
+        Self { connection_info }
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if there was an error while sending request, redirect loop
+    /// was detected or redirect limit was exhausted.    
+    pub async fn get(&self, path: &str, params: Query) -> TextResponse {
+        let response = match &self.connection_info.token {
+            Some(token) => reqwest::Client::builder()
+                .build()
+                .unwrap()
+                .get(self.base_url(path).clone())
+                .query(&ReqwestQuery::from(params))
+                .bearer_auth(token)
+                .send()
+                .await
+                .unwrap(),
+            None => reqwest::Client::builder()
+                .build()
+                .unwrap()
+                .get(self.base_url(path).clone())
+                .query(&ReqwestQuery::from(params))
+                .send()
+                .await
+                .unwrap(),
+        };
+        TextResponse::from(response).await
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if there was an error while sending request, redirect loop
+    /// was detected or redirect limit was exhausted.    
+    pub async fn get_binary(&self, path: &str, params: Query) -> BinaryResponse {
+        let response = match &self.connection_info.token {
+            Some(token) => reqwest::Client::builder()
+                .build()
+                .unwrap()
+                .get(self.base_url(path).clone())
+                .query(&ReqwestQuery::from(params))
+                .bearer_auth(token)
+                .send()
+                .await
+                .unwrap(),
+            None => reqwest::Client::builder()
+                .build()
+                .unwrap()
+                .get(self.base_url(path).clone())
+                .query(&ReqwestQuery::from(params))
+                .send()
+                .await
+                .unwrap(),
+        };
+        // todo: If the response is a JSON, it returns the JSON body in a byte
+        //   array. This is not the expected behavior.
+        //  - Rename BinaryResponse to BinaryTorrentResponse
+        //  - Return an error if the response is not a bittorrent file
+        BinaryResponse::from(response).await
+    }
+
+    /// # Errors
+    ///
+    /// Will fail if there was an error while sending request, redirect loop
+    /// was detected or redirect limit was exhausted.
+    ///
+    /// # Panics
+    ///
+    /// This method fails it can't build a `reqwest` client.
+    pub async fn inner_get(&self, path: &str) -> Result<reqwest::Response, reqwest::Error> {
+        reqwest::Client::builder()
+            .build()
+            .unwrap()
+            .get(self.base_url(path).clone())
+            .send()
+            .await
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if there was an error while sending request, redirect loop
+    /// was detected or redirect limit was exhausted.    
+    pub async fn post<T: Serialize + ?Sized>(&self, path: &str, form: &T) -> TextResponse {
+        let response = match &self.connection_info.token {
+            Some(token) => reqwest::Client::new()
+                .post(self.base_url(path).clone())
+                .bearer_auth(token)
+                .json(&form)
+                .send()
+                .await
+                .unwrap(),
+            None => reqwest::Client::new()
+                .post(self.base_url(path).clone())
+                .json(&form)
+                .send()
+                .await
+                .unwrap(),
+        };
+        TextResponse::from(response).await
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if there was an error while sending request, redirect loop
+    /// was detected or redirect limit was exhausted.    
+    pub async fn post_multipart(&self, path: &str, form: multipart::Form) -> TextResponse {
+        let response = match &self.connection_info.token {
+            Some(token) => reqwest::Client::builder()
+                .build()
+                .unwrap()
+                .post(self.base_url(path).clone())
+                .multipart(form)
+                .bearer_auth(token)
+                .send()
+                .await
+                .expect("failed to send multipart request with token"),
+            None => reqwest::Client::builder()
+                .build()
+                .unwrap()
+                .post(self.base_url(path).clone())
+                .multipart(form)
+                .send()
+                .await
+                .expect("failed to send multipart request without token"),
+        };
+        TextResponse::from(response).await
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if there was an error while sending request, redirect loop
+    /// was detected or redirect limit was exhausted.
+    pub async fn put<T: Serialize + ?Sized>(&self, path: &str, form: &T) -> TextResponse {
+        let response = match &self.connection_info.token {
+            Some(token) => reqwest::Client::new()
+                .put(self.base_url(path).clone())
+                .bearer_auth(token)
+                .json(&form)
+                .send()
+                .await
+                .unwrap(),
+            None => reqwest::Client::new()
+                .put(self.base_url(path).clone())
+                .json(&form)
+                .send()
+                .await
+                .unwrap(),
+        };
+        TextResponse::from(response).await
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if there was an error while sending request, redirect loop
+    /// was detected or redirect limit was exhausted.    
+    pub async fn delete(&self, path: &str) -> TextResponse {
+        let response = match &self.connection_info.token {
+            Some(token) => reqwest::Client::new()
+                .delete(self.base_url(path).clone())
+                .bearer_auth(token)
+                .send()
+                .await
+                .unwrap(),
+            None => reqwest::Client::new()
+                .delete(self.base_url(path).clone())
+                .send()
+                .await
+                .unwrap(),
+        };
+        TextResponse::from(response).await
+    }
+
+    /// # Panics
+    ///
+    /// Will panic if there was an error while sending request, redirect loop
+    /// was detected or redirect limit was exhausted.
+    pub async fn delete_with_body<T: Serialize + ?Sized>(&self, path: &str, form: &T) -> TextResponse {
+        let response = match &self.connection_info.token {
+            Some(token) => reqwest::Client::new()
+                .delete(self.base_url(path).clone())
+                .bearer_auth(token)
+                .json(&form)
+                .send()
+                .await
+                .unwrap(),
+            None => reqwest::Client::new()
+                .delete(self.base_url(path).clone())
+                .json(&form)
+                .send()
+                .await
+                .unwrap(),
+        };
+        TextResponse::from(response).await
+    }
+
+    fn base_url(&self, path: &str) -> String {
+        format!(
+            "http://{}{}{path}",
+            &self.connection_info.bind_address, &self.connection_info.base_path
+        )
     }
 }

--- a/src/web/api/client/v1/http.rs
+++ b/src/web/api/client/v1/http.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use reqwest::multipart;
 use serde::Serialize;
 
@@ -65,12 +67,18 @@ impl From<QueryParam> for ReqwestQueryParam {
 /// Generic HTTP Client
 pub struct Http {
     connection_info: ConnectionInfo,
+    /// The timeout is applied from when the request starts connecting until the
+    /// response body has finished.
+    timeout: Duration,
 }
 
 impl Http {
     #[must_use]
     pub fn new(connection_info: ConnectionInfo) -> Self {
-        Self { connection_info }
+        Self {
+            connection_info,
+            timeout: Duration::from_secs(5),
+        }
     }
 
     /// # Panics
@@ -80,6 +88,7 @@ impl Http {
     pub async fn get(&self, path: &str, params: Query) -> TextResponse {
         let response = match &self.connection_info.token {
             Some(token) => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .get(self.base_url(path).clone())
@@ -89,6 +98,7 @@ impl Http {
                 .await
                 .unwrap(),
             None => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .get(self.base_url(path).clone())
@@ -107,6 +117,7 @@ impl Http {
     pub async fn get_binary(&self, path: &str, params: Query) -> BinaryResponse {
         let response = match &self.connection_info.token {
             Some(token) => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .get(self.base_url(path).clone())
@@ -116,6 +127,7 @@ impl Http {
                 .await
                 .unwrap(),
             None => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .get(self.base_url(path).clone())
@@ -141,6 +153,7 @@ impl Http {
     /// This method fails it can't build a `reqwest` client.
     pub async fn inner_get(&self, path: &str) -> Result<reqwest::Response, reqwest::Error> {
         reqwest::Client::builder()
+            .timeout(self.timeout)
             .build()
             .unwrap()
             .get(self.base_url(path).clone())
@@ -178,6 +191,7 @@ impl Http {
     pub async fn post_multipart(&self, path: &str, form: multipart::Form) -> TextResponse {
         let response = match &self.connection_info.token {
             Some(token) => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .post(self.base_url(path).clone())
@@ -187,6 +201,7 @@ impl Http {
                 .await
                 .expect("failed to send multipart request with token"),
             None => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .post(self.base_url(path).clone())

--- a/src/web/api/server/v1/routes.rs
+++ b/src/web/api/server/v1/routes.rs
@@ -20,6 +20,7 @@ pub const API_VERSION_URL_PREFIX: &str = "v1";
 #[allow(clippy::needless_pass_by_value)]
 pub fn router(app_data: Arc<AppData>) -> Router {
     // code-review: should we use plural for the resource prefix: `users`, `categories`, `tags`?
+    // Some endpoint are using plural (for instance, `get_categories`) and some singular.
     // See: https://stackoverflow.com/questions/6845772/should-i-use-singular-or-plural-name-convention-for-rest-resources
 
     let v1_api_routes = Router::new()

--- a/tests/common/client.rs
+++ b/tests/common/client.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use reqwest::multipart;
 use serde::Serialize;
 
@@ -158,16 +160,23 @@ impl Client {
 /// Generic HTTP Client
 struct Http {
     connection_info: ConnectionInfo,
+    /// The timeout is applied from when the request starts connecting until the
+    /// response body has finished.
+    timeout: Duration,
 }
 
 impl Http {
     pub fn new(connection_info: ConnectionInfo) -> Self {
-        Self { connection_info }
+        Self {
+            connection_info,
+            timeout: Duration::from_secs(5),
+        }
     }
 
     pub async fn get(&self, path: &str, params: Query) -> TextResponse {
         let response = match &self.connection_info.token {
             Some(token) => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .get(self.base_url(path).clone())
@@ -177,6 +186,7 @@ impl Http {
                 .await
                 .unwrap(),
             None => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .get(self.base_url(path).clone())
@@ -191,6 +201,7 @@ impl Http {
     pub async fn get_binary(&self, path: &str, params: Query) -> BinaryResponse {
         let response = match &self.connection_info.token {
             Some(token) => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .get(self.base_url(path).clone())
@@ -200,6 +211,7 @@ impl Http {
                 .await
                 .unwrap(),
             None => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .get(self.base_url(path).clone())
@@ -217,6 +229,7 @@ impl Http {
 
     pub async fn inner_get(&self, path: &str) -> Result<reqwest::Response, reqwest::Error> {
         reqwest::Client::builder()
+            .timeout(self.timeout)
             .build()
             .unwrap()
             .get(self.base_url(path).clone())
@@ -246,6 +259,7 @@ impl Http {
     pub async fn post_multipart(&self, path: &str, form: multipart::Form) -> TextResponse {
         let response = match &self.connection_info.token {
             Some(token) => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .post(self.base_url(path).clone())
@@ -255,6 +269,7 @@ impl Http {
                 .await
                 .expect("failed to send multipart request with token"),
             None => reqwest::Client::builder()
+                .timeout(self.timeout)
                 .build()
                 .unwrap()
                 .post(self.base_url(path).clone())


### PR DESCRIPTION
The API client does not have any timeout. The client waits indefinitely for responses. That should not be the default behaviour. It should return an error after a timeout. The users using the client should handle the timeout or any other error.

### Subtasks

- [x] Move generic HTTP client to HTTP mod.
- [x] Generic HTTP client: Inject the scheme part of the URL in the constructor.
- [x] Add timeouts to the generic HTTP client.
- [x] Remove `unwraps` from the generic HTTP client. Return errors.
- [x] Remove `unwraps` from the Index API HTTP client. Return errors.