### PR TITLE
Add timeouts to Tracker API Client requests

### DIFF
--- a/src/tracker/api.rs
+++ b/src/tracker/api.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use reqwest::{Error, Response};
 pub struct ConnectionInfo {
     /// The URL of the tracker. Eg: <https://tracker:7070> or <udp://tracker:6969>
@@ -15,6 +17,7 @@ impl ConnectionInfo {
 
 pub struct Client {
     pub connection_info: ConnectionInfo,
+    timeout: Duration,
     base_url: String,
 }
 
@@ -24,6 +27,7 @@ impl Client {
         let base_url = format!("{}/api/v1", connection_info.url);
         Self {
             connection_info,
+            timeout: Duration::from_secs(5),
             base_url,
         }
     }
@@ -36,7 +40,7 @@ impl Client {
     pub async fn whitelist_torrent(&self, info_hash: &str) -> Result<Response, Error> {
         let request_url = format!("{}/whitelist/{}", self.base_url, info_hash);
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder().timeout(self.timeout).build()?;
 
         let params = [("token", &self.connection_info.token)];
 
@@ -51,7 +55,7 @@ impl Client {
     pub async fn remove_torrent_from_whitelist(&self, info_hash: &str) -> Result<Response, Error> {
         let request_url = format!("{}/whitelist/{}", self.base_url, info_hash);
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder().timeout(self.timeout).build()?;
 
         let params = [("token", &self.connection_info.token)];
 
@@ -66,7 +70,7 @@ impl Client {
     pub async fn retrieve_new_tracker_key(&self, token_valid_seconds: u64) -> Result<Response, Error> {
         let request_url = format!("{}/key/{}", self.base_url, token_valid_seconds);
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder().timeout(self.timeout).build()?;
 
         let params = [("token", &self.connection_info.token)];
 
@@ -81,7 +85,7 @@ impl Client {
     pub async fn get_torrent_info(&self, info_hash: &str) -> Result<Response, Error> {
         let request_url = format!("{}/torrent/{}", self.base_url, info_hash);
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder().timeout(self.timeout).build()?;
 
         let params = [("token", &self.connection_info.token)];
 

--- a/src/tracker/api.rs
+++ b/src/tracker/api.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use reqwest::{Error, Response};
 pub struct ConnectionInfo {
-    /// The URL of the tracker. Eg: <https://tracker:7070> or <udp://tracker:6969>
+    /// The URL of the tracker API. Eg: <https://tracker:1212>.
     pub url: String,
     /// The token used to authenticate with the tracker API.
     pub token: String,
@@ -17,19 +17,26 @@ impl ConnectionInfo {
 
 pub struct Client {
     pub connection_info: ConnectionInfo,
-    timeout: Duration,
-    base_url: String,
+    api_base_url: String,
+    client: reqwest::Client,
+    token_param: [(String, String); 1],
 }
 
 impl Client {
-    #[must_use]
-    pub fn new(connection_info: ConnectionInfo) -> Self {
+    /// # Errors
+    ///
+    /// Will fails if it can't build a HTTP client with a timeout.
+    pub fn new(connection_info: ConnectionInfo) -> Result<Self, Error> {
         let base_url = format!("{}/api/v1", connection_info.url);
-        Self {
+        let client = reqwest::Client::builder().timeout(Duration::from_secs(5)).build()?;
+        let token_param = [("token".to_string(), connection_info.token.to_string())];
+
+        Ok(Self {
             connection_info,
-            timeout: Duration::from_secs(5),
-            base_url,
-        }
+            api_base_url: base_url,
+            client,
+            token_param,
+        })
     }
 
     /// Add a torrent to the tracker whitelist.
@@ -38,13 +45,9 @@ impl Client {
     ///
     /// Will return an error if the HTTP request fails.
     pub async fn whitelist_torrent(&self, info_hash: &str) -> Result<Response, Error> {
-        let request_url = format!("{}/whitelist/{}", self.base_url, info_hash);
+        let request_url = format!("{}/whitelist/{}", self.api_base_url, info_hash);
 
-        let client = reqwest::Client::builder().timeout(self.timeout).build()?;
-
-        let params = [("token", &self.connection_info.token)];
-
-        client.post(request_url).query(&params).send().await
+        self.client.post(request_url).query(&self.token_param).send().await
     }
 
     /// Remove a torrent from the tracker whitelist.
@@ -53,13 +56,9 @@ impl Client {
     ///
     /// Will return an error if the HTTP request fails.
     pub async fn remove_torrent_from_whitelist(&self, info_hash: &str) -> Result<Response, Error> {
-        let request_url = format!("{}/whitelist/{}", self.base_url, info_hash);
+        let request_url = format!("{}/whitelist/{}", self.api_base_url, info_hash);
 
-        let client = reqwest::Client::builder().timeout(self.timeout).build()?;
-
-        let params = [("token", &self.connection_info.token)];
-
-        client.delete(request_url).query(&params).send().await
+        self.client.delete(request_url).query(&self.token_param).send().await
     }
 
     /// Retrieve a new tracker key.
@@ -68,13 +67,9 @@ impl Client {
     ///
     /// Will return an error if the HTTP request fails.
     pub async fn retrieve_new_tracker_key(&self, token_valid_seconds: u64) -> Result<Response, Error> {
-        let request_url = format!("{}/key/{}", self.base_url, token_valid_seconds);
+        let request_url = format!("{}/key/{}", self.api_base_url, token_valid_seconds);
 
-        let client = reqwest::Client::builder().timeout(self.timeout).build()?;
-
-        let params = [("token", &self.connection_info.token)];
-
-        client.post(request_url).query(&params).send().await
+        self.client.post(request_url).query(&self.token_param).send().await
     }
 
     /// Retrieve the info for a torrent.
@@ -83,12 +78,8 @@ impl Client {
     ///
     /// Will return an error if the HTTP request fails.
     pub async fn get_torrent_info(&self, info_hash: &str) -> Result<Response, Error> {
-        let request_url = format!("{}/torrent/{}", self.base_url, info_hash);
+        let request_url = format!("{}/torrent/{}", self.api_base_url, info_hash);
 
-        let client = reqwest::Client::builder().timeout(self.timeout).build()?;
-
-        let params = [("token", &self.connection_info.token)];
-
-        client.get(request_url).query(&params).send().await
+        self.client.get(request_url).query(&self.token_param).send().await
     }
 }

--- a/src/tracker/service.rs
+++ b/src/tracker/service.rs
@@ -73,12 +73,16 @@ pub struct Service {
 }
 
 impl Service {
+    /// # Panics
+    ///
+    /// Will panic if it can't build a Tracker API client.
     pub async fn new(cfg: Arc<Configuration>, database: Arc<Box<dyn Database>>) -> Service {
         let settings = cfg.settings.read().await;
         let api_client = Client::new(ConnectionInfo::new(
             settings.tracker.api_url.clone(),
             settings.tracker.token.clone(),
-        ));
+        ))
+        .expect("a reqwest client should be provided");
         let token_valid_seconds = settings.tracker.token_valid_seconds;
         let tracker_url = settings.tracker.url.clone();
         drop(settings);


### PR DESCRIPTION
Ass default timeout of 5 seconds for Tracker API requests.

In the future, we could use the official Tracker API client. See https://github.com/torrust/torrust-tracker/issues/689.

However, it's also fine to use this reduced client. Because we do not need all the PAI endpoints.