### PR TITLE
Overhaul logging

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -54,7 +54,7 @@ jobs:
         name: Install Tools
         uses: taiki-e/install-action@v2
         with:
-          tool: grcov
+          tool: cargo-llvm-cov, cargo-nextest, grcov
 
       - id: imdl
         name: Install Intermodal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,6 +3200,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,6 +3149,8 @@ dependencies = [
  "toml",
  "torrust-index-located-error",
  "tower-http",
+ "trace",
+ "tracing",
  "urlencoding",
  "uuid",
  "which",
@@ -3197,6 +3199,7 @@ dependencies = [
  "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3210,6 +3213,17 @@ name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "trace"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ad0c048e114d19d1140662762bfdb10682f3bc806d8be18af846600214dd9af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,9 @@ thiserror = "1"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 toml = "0"
 torrust-index-located-error = { version = "3.0.0-alpha.3-develop", path = "packages/located-error" }
-tower-http = { version = "0", features = ["compression-full", "cors"] }
+tower-http = { version = "0", features = ["compression-full", "cors", "trace"] }
+trace = "0.1.7"
+tracing = "0.1.40"
 urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 toml = "0"
 torrust-index-located-error = { version = "3.0.0-alpha.3-develop", path = "packages/located-error" }
-tower-http = { version = "0", features = ["compression-full", "cors", "trace"] }
+tower-http = { version = "0", features = ["compression-full", "cors", "trace", "propagate-header", "request-id"] }
 trace = "0.1.7"
 tracing = "0.1.40"
 urlencoding = "2"

--- a/src/web/api/server/v1/routes.rs
+++ b/src/web/api/server/v1/routes.rs
@@ -57,8 +57,8 @@ pub fn router(app_data: Arc<AppData>) -> Router {
     router
         .layer(DefaultBodyLimit::max(10_485_760))
         .layer(CompressionLayer::new())
-        .layer(PropagateHeaderLayer::new(HeaderName::from_static("x-request-id")))
         .layer(SetRequestIdLayer::x_request_id(RequestIdGenerator))
+        .layer(PropagateHeaderLayer::new(HeaderName::from_static("x-request-id")))
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
@@ -89,6 +89,7 @@ pub fn router(app_data: Arc<AppData>) -> Router {
                         tracing::Level::INFO, "response", latency = %latency_ms, status = %status_code, request_id = %request_id);
                 }),
         )
+        .layer(SetRequestIdLayer::x_request_id(RequestIdGenerator))
 }
 
 /// Endpoint for container health check.


### PR DESCRIPTION
Overhaul logging.

- [x] Improve tracker stats importer logs.
- [x] Improve tracker API logs.
   - [x] Enable default logging for Axum API requests.
   - [x] Link requests and responses with an ID.
   - [x] Add target `API` to the log lines.