### PR TITLE
Allow upload torrent with `application/octet-stream` HTTP header Content-Type

### DIFF
--- a/src/web/api/client/v1/responses.rs
+++ b/src/web/api/client/v1/responses.rs
@@ -71,13 +71,21 @@ impl BinaryResponse {
 
     #[must_use]
     pub fn is_a_bit_torrent_file(&self) -> bool {
-        self.is_ok() && self.is_bittorrent_content_type()
+        self.is_ok() && (self.is_bittorrent_content_type() || self.is_octet_stream_content_type())
     }
 
     #[must_use]
     pub fn is_bittorrent_content_type(&self) -> bool {
         if let Some(content_type) = &self.content_type {
             return content_type == "application/x-bittorrent";
+        }
+        false
+    }
+
+    #[must_use]
+    pub fn is_octet_stream_content_type(&self) -> bool {
+        if let Some(content_type) = &self.content_type {
+            return content_type == "application/octet-stream";
         }
         false
     }

--- a/src/web/api/server/v1/contexts/torrent/errors.rs
+++ b/src/web/api/server/v1/contexts/torrent/errors.rs
@@ -21,7 +21,9 @@ pub enum Request {
     #[display(fmt = "torrent tags string is not a valid JSON.")]
     TagsArrayIsNotValidJson,
 
-    #[display(fmt = "upload torrent request header `content-type` should be `application/x-bittorrent`.")]
+    #[display(
+        fmt = "upload torrent request header `content-type` should be preferably `application/x-bittorrent` or `application/octet-stream`."
+    )]
     InvalidFileType,
 
     #[display(fmt = "cannot write uploaded torrent bytes (binary file) into memory.")]

--- a/src/web/api/server/v1/contexts/torrent/handlers.rs
+++ b/src/web/api/server/v1/contexts/torrent/handlers.rs
@@ -301,7 +301,7 @@ pub async fn create_random_torrent_handler(State(_app_data): State<Arc<AppData>>
 ///
 /// - The text fields do not contain a valid UTF8 string.
 /// - The torrent file data is not valid because:
-///    - The content type is not `application/x-bittorrent`.
+///    - The content type is not `application/x-bittorrent` or `application/octet-stream`.
 ///    - The multipart content is invalid.
 ///    - The torrent file pieces key has a length that is not a multiple of 20.
 ///    - The binary data cannot be decoded as a torrent file.
@@ -350,7 +350,7 @@ async fn build_add_torrent_request_from_payload(mut payload: Multipart) -> Resul
             "torrent" => {
                 let content_type = field.content_type().unwrap();
 
-                if content_type != "application/x-bittorrent" {
+                if content_type != "application/x-bittorrent" && content_type != "application/octet-stream" {
                     return Err(errors::Request::InvalidFileType);
                 }
 

--- a/tests/common/responses.rs
+++ b/tests/common/responses.rs
@@ -54,12 +54,19 @@ impl BinaryResponse {
         }
     }
     pub fn is_a_bit_torrent_file(&self) -> bool {
-        self.is_ok() && self.is_bittorrent_content_type()
+        self.is_ok() && (self.is_bittorrent_content_type() || self.is_octet_stream_content_type())
     }
 
     pub fn is_bittorrent_content_type(&self) -> bool {
         if let Some(content_type) = &self.content_type {
             return content_type == "application/x-bittorrent";
+        }
+        false
+    }
+
+    pub fn is_octet_stream_content_type(&self) -> bool {
+        if let Some(content_type) = &self.content_type {
+            return content_type == "application/octet-stream";
         }
         false
     }


### PR DESCRIPTION
Relates to: https://github.com/torrust/torrust-index-gui/issues/483

Some users are having problems uploading torrents becuase the client (browser or other clients) use the HTTP header Contetnt-Type:

`application/octet-stream`

instead of:

`application/x-bittorrent`

It seems that the reason is they don't have any application associated to that extension. So it uses the generic binary file mime type.

The MIME type can be inferred from the file extension. If the system or application uploading the file has a specific association for .torrent files, it might set the MIME type to application/x-bittorrent. In the absence of such an association, it might fall back to the generic application/octet-stream.