### PR TITLE
Decouple database strcut from API response for `Category`

### DIFF
--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -1,2 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+use crate::databases::database::Category as DatabaseCategory;
+
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct Category {
+    pub id: i64,
+    // Deprecated. Use `id`.
+    pub category_id: i64,
+    pub name: String,
+    pub num_torrents: i64,
+}
+
 #[allow(clippy::module_name_repetitions)]
 pub type CategoryId = i64;
+
+impl From<DatabaseCategory> for Category {
+    fn from(db_category: DatabaseCategory) -> Self {
+        Category {
+            id: db_category.category_id,
+            category_id: db_category.category_id,
+            name: db_category.name,
+            num_torrents: db_category.num_torrents,
+        }
+    }
+}

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+use super::category::Category;
 use super::torrent::TorrentId;
-use crate::databases::database::Category;
+use crate::databases::database::Category as DatabaseCategory;
 use crate::models::torrent::TorrentListing;
 use crate::models::torrent_file::TorrentFile;
 use crate::models::torrent_tag::TorrentTag;
@@ -70,14 +71,14 @@ pub struct TorrentResponse {
 
 impl TorrentResponse {
     #[must_use]
-    pub fn from_listing(torrent_listing: TorrentListing, category: Option<Category>) -> TorrentResponse {
+    pub fn from_listing(torrent_listing: TorrentListing, category: Option<DatabaseCategory>) -> TorrentResponse {
         TorrentResponse {
             torrent_id: torrent_listing.torrent_id,
             uploader: torrent_listing.uploader,
             info_hash: torrent_listing.info_hash,
             title: torrent_listing.title,
             description: torrent_listing.description,
-            category,
+            category: category.map(std::convert::Into::into),
             upload_date: torrent_listing.date_uploaded,
             file_size: torrent_listing.file_size,
             seeders: torrent_listing.seeders,

--- a/src/web/api/client/v1/contexts/torrent/responses.rs
+++ b/src/web/api/client/v1/contexts/torrent/responses.rs
@@ -75,11 +75,9 @@ pub struct TorrentDetails {
     pub encoding: Option<String>,
 }
 
-#[allow(unknown_lints)]
-#[allow(clippy::struct_field_names)]
 #[derive(Deserialize, PartialEq, Debug)]
 pub struct Category {
-    pub category_id: CategoryId, // todo: rename to `id`
+    pub id: CategoryId,
     pub name: String,
     pub num_torrents: u64,
 }

--- a/src/web/api/server/v1/contexts/category/handlers.rs
+++ b/src/web/api/server/v1/contexts/category/handlers.rs
@@ -6,7 +6,7 @@ use axum::extract::{self, State};
 use axum::response::{IntoResponse, Json, Response};
 
 use super::forms::{AddCategoryForm, DeleteCategoryForm};
-use super::responses::{added_category, deleted_category};
+use super::responses::{added_category, deleted_category, Category};
 use crate::common::AppData;
 use crate::web::api::server::v1::extractors::user_id::ExtractLoggedInUser;
 use crate::web::api::server::v1::responses::{self};
@@ -27,7 +27,10 @@ use crate::web::api::server::v1::responses::{self};
 #[allow(clippy::unused_async)]
 pub async fn get_all_handler(State(app_data): State<Arc<AppData>>) -> Response {
     match app_data.category_repository.get_all().await {
-        Ok(categories) => Json(responses::OkResponseData { data: categories }).into_response(),
+        Ok(categories) => {
+            let categories: Vec<Category> = categories.into_iter().map(Category::from).collect();
+            Json(responses::OkResponseData { data: categories }).into_response()
+        }
         Err(error) => error.into_response(),
     }
 }

--- a/src/web/api/server/v1/contexts/category/responses.rs
+++ b/src/web/api/server/v1/contexts/category/responses.rs
@@ -1,8 +1,19 @@
 //! API responses for the the [`category`](crate::web::api::server::v1::contexts::category) API
 //! context.
 use axum::Json;
+use serde::{Deserialize, Serialize};
 
+use crate::databases::database::Category as DatabaseCategory;
 use crate::web::api::server::v1::responses::OkResponseData;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Category {
+    pub id: i64,
+    /// Deprecated. Use `id`.
+    pub category_id: i64, // todo: remove when the Index GUI uses the new `id` field.
+    pub name: String,
+    pub num_torrents: i64,
+}
 
 /// Response after successfully creating a new category.
 pub fn added_category(category_name: &str) -> Json<OkResponseData<String>> {
@@ -16,4 +27,15 @@ pub fn deleted_category(category_name: &str) -> Json<OkResponseData<String>> {
     Json(OkResponseData {
         data: category_name.to_string(),
     })
+}
+
+impl From<DatabaseCategory> for Category {
+    fn from(db_category: DatabaseCategory) -> Self {
+        Category {
+            id: db_category.category_id,
+            category_id: db_category.category_id,
+            name: db_category.name,
+            num_torrents: db_category.num_torrents,
+        }
+    }
 }

--- a/tests/common/contexts/torrent/asserts.rs
+++ b/tests/common/contexts/torrent/asserts.rs
@@ -15,10 +15,7 @@ pub fn assert_expected_torrent_details(torrent: &TorrentDetails, expected_torren
         ("info_hash", torrent.info_hash == expected_torrent.info_hash),
         ("title", torrent.title == expected_torrent.title),
         ("description", torrent.description == expected_torrent.description),
-        (
-            "category.category_id",
-            torrent.category.category_id == expected_torrent.category.category_id,
-        ),
+        ("category.id", torrent.category.id == expected_torrent.category.id),
         ("category.name", torrent.category.name == expected_torrent.category.name),
         ("file_size", torrent.file_size == expected_torrent.file_size),
         ("seeders", torrent.seeders == expected_torrent.seeders),

--- a/tests/common/contexts/torrent/responses.rs
+++ b/tests/common/contexts/torrent/responses.rs
@@ -74,11 +74,9 @@ pub struct TorrentDetails {
     pub encoding: Option<String>,
 }
 
-#[allow(unknown_lints)]
-#[allow(clippy::struct_field_names)]
 #[derive(Deserialize, PartialEq, Debug)]
 pub struct Category {
-    pub category_id: CategoryId, // todo: rename to `id`
+    pub id: CategoryId,
     pub name: String,
     pub num_torrents: u64,
 }

--- a/tests/e2e/web/api/v1/contexts/torrent/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/contract.rs
@@ -182,7 +182,7 @@ mod for_guests {
             title: test_torrent.index_info.title.clone(),
             description: test_torrent.index_info.description,
             category: Category {
-                category_id: software_predefined_category_id(),
+                id: software_predefined_category_id(),
                 name: test_torrent.index_info.category,
                 num_torrents: 19, // Ignored in assertion
             },


### PR DESCRIPTION
Decouple database struct from API response for `Category`. Changes in the database schema should not affect the API contract.