### PR TITLE
BEP 17. Persist metainfo field `httpseeds`

### DIFF
--- a/migrations/mysql/20240304104106_torrust_add_http_seeds_to_torrent.sql
+++ b/migrations/mysql/20240304104106_torrust_add_http_seeds_to_torrent.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS torrust_torrent_http_seeds (
+    http_seed_id INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    torrent_id INTEGER NOT NULL,
+    seed_url VARCHAR(256) NOT NULL,
+    FOREIGN KEY(torrent_id) REFERENCES torrust_torrents(torrent_id) ON DELETE CASCADE
+)

--- a/migrations/sqlite3/20240304104106_torrust_add_http_seeds_to_torrent.sql
+++ b/migrations/sqlite3/20240304104106_torrust_add_http_seeds_to_torrent.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS torrust_torrent_http_seeds (
+    http_seed_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    torrent_id INTEGER NOT NULL,
+    seed_url TEXT NOT NULL,
+    FOREIGN KEY(torrent_id) REFERENCES torrust_torrents(torrent_id) ON DELETE CASCADE
+)

--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -206,7 +206,14 @@ pub trait Database: Sync + Send {
 
         let torrent_announce_urls = self.get_torrent_announce_urls_from_id(db_torrent.torrent_id).await?;
 
-        Ok(Torrent::from_database(&db_torrent, &torrent_files, torrent_announce_urls))
+        let torrent_http_seed_urls = self.get_torrent_http_seed_urls_from_id(db_torrent.torrent_id).await?;
+
+        Ok(Torrent::from_database(
+            &db_torrent,
+            &torrent_files,
+            torrent_announce_urls,
+            torrent_http_seed_urls,
+        ))
     }
 
     /// Get `Torrent` from `torrent_id`.
@@ -217,7 +224,14 @@ pub trait Database: Sync + Send {
 
         let torrent_announce_urls = self.get_torrent_announce_urls_from_id(torrent_id).await?;
 
-        Ok(Torrent::from_database(&db_torrent, &torrent_files, torrent_announce_urls))
+        let torrent_http_seed_urls = self.get_torrent_http_seed_urls_from_id(db_torrent.torrent_id).await?;
+
+        Ok(Torrent::from_database(
+            &db_torrent,
+            &torrent_files,
+            torrent_announce_urls,
+            torrent_http_seed_urls,
+        ))
     }
 
     /// It returns the list of all infohashes producing the same canonical
@@ -256,6 +270,9 @@ pub trait Database: Sync + Send {
 
     /// Get all torrent's announce urls as `Vec<Vec<String>>` from `torrent_id`.
     async fn get_torrent_announce_urls_from_id(&self, torrent_id: i64) -> Result<Vec<Vec<String>>, Error>;
+
+    /// Get all torrent's HTTP seed urls as `Vec<Vec<String>>` from `torrent_id`.
+    async fn get_torrent_http_seed_urls_from_id(&self, torrent_id: i64) -> Result<Vec<String>, Error>;
 
     /// Get `TorrentListing` from `torrent_id`.
     async fn get_torrent_listing_from_id(&self, torrent_id: i64) -> Result<TorrentListing, Error>;

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -13,7 +13,7 @@ use crate::models::category::CategoryId;
 use crate::models::info_hash::InfoHash;
 use crate::models::response::TorrentsResponse;
 use crate::models::torrent::{Metadata, TorrentListing};
-use crate::models::torrent_file::{DbTorrent, DbTorrentAnnounceUrl, DbTorrentFile, Torrent, TorrentFile};
+use crate::models::torrent_file::{DbTorrent, DbTorrentAnnounceUrl, DbTorrentFile, DbTorrentHttpSeedUrl, Torrent, TorrentFile};
 use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserId, UserProfile};
@@ -582,7 +582,31 @@ impl Database for Mysql {
             return Err(e);
         }
 
-        // Insert tags
+        // add HTTP seeds
+
+        let insert_torrent_http_seeds_result: Result<(), database::Error> = if let Some(http_seeds) = &torrent.httpseeds {
+            for seed_url in http_seeds {
+                let () = query("INSERT INTO torrust_torrent_http_seeds (torrent_id, seed_url) VALUES (?, ?)")
+                    .bind(torrent_id)
+                    .bind(seed_url)
+                    .execute(&mut *tx)
+                    .await
+                    .map(|_| ())
+                    .map_err(|_| database::Error::Error)?;
+            }
+
+            Ok(())
+        } else {
+            Ok(())
+        };
+
+        // rollback transaction on error
+        if let Err(e) = insert_torrent_http_seeds_result {
+            drop(tx.rollback().await);
+            return Err(e);
+        }
+
+        // add tags
 
         for tag_id in &metadata.tags {
             let insert_torrent_tag_result = query("INSERT INTO torrust_torrent_tag_links (torrent_id, tag_id) VALUES (?, ?)")
@@ -737,6 +761,15 @@ impl Database for Mysql {
             .fetch_all(&self.pool)
             .await
             .map(|v| v.iter().map(|a| vec![a.tracker_url.to_string()]).collect())
+            .map_err(|_| database::Error::TorrentNotFound)
+    }
+
+    async fn get_torrent_http_seed_urls_from_id(&self, torrent_id: i64) -> Result<Vec<String>, database::Error> {
+        query_as::<_, DbTorrentHttpSeedUrl>("SELECT seed_url FROM torrust_torrent_http_seeds WHERE torrent_id = ?")
+            .bind(torrent_id)
+            .fetch_all(&self.pool)
+            .await
+            .map(|v| v.iter().map(|a| a.seed_url.to_string()).collect())
             .map_err(|_| database::Error::TorrentNotFound)
     }
 

--- a/src/models/torrent_file.rs
+++ b/src/models/torrent_file.rs
@@ -70,7 +70,12 @@ impl Torrent {
     /// This function will panic if the `torrent_info.pieces` is not a valid
     /// hex string.
     #[must_use]
-    pub fn from_database(db_torrent: &DbTorrent, torrent_files: &[TorrentFile], torrent_announce_urls: Vec<Vec<String>>) -> Self {
+    pub fn from_database(
+        db_torrent: &DbTorrent,
+        torrent_files: &[TorrentFile],
+        torrent_announce_urls: Vec<Vec<String>>,
+        torrent_http_seed_urls: Vec<String>,
+    ) -> Self {
         let info_dict = TorrentInfoDictionary::with(
             &db_torrent.name,
             db_torrent.piece_length,
@@ -85,7 +90,11 @@ impl Torrent {
             announce: None,
             nodes: None,
             encoding: db_torrent.encoding.clone(),
-            httpseeds: None,
+            httpseeds: if torrent_http_seed_urls.is_empty() {
+                None
+            } else {
+                Some(torrent_http_seed_urls)
+            },
             announce_list: Some(torrent_announce_urls),
             creation_date: db_torrent.creation_date,
             comment: db_torrent.comment.clone(),
@@ -343,6 +352,11 @@ pub struct DbTorrentFile {
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct DbTorrentAnnounceUrl {
     pub tracker_url: String,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct DbTorrentHttpSeedUrl {
+    pub seed_url: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The field `httpseeds` was included in the `Torrent` struct but not persisted into or loaded from database.