### PR TITLE
Add `announce` field to test torrent

### DIFF
--- a/src/bin/create_test_torrent.rs
+++ b/src/bin/create_test_torrent.rs
@@ -42,7 +42,7 @@ fn main() {
                 md5sum: None, // DevSkim: ignore DS126858
             }],
         ),
-        announce: None,
+        announce: Some("https://tracker.torrust-demo.com/announce".to_string()),
         nodes: Some(vec![("99.236.6.144".to_string(), 6881), ("91.109.195.156".to_string(), 1996)]),
         encoding: None,
         httpseeds: Some(vec!["https://seeder.torrust-demo.com/seed".to_string()]),


### PR DESCRIPTION
Add `announce` field to test torrent.

With the command:

```
cargo run --bin create_test_torrent ./output/test/torrents
```

You can generate a test torrent. Currently, it does now add all the optional fields. We are adding them when we need them.