### PR TITLE
Refactor BEP 30 implmentation

### DIFF
--- a/migrations/mysql/20240305110750_torrust_bep_rename_root_hash_to_is_bep_30.sql
+++ b/migrations/mysql/20240305110750_torrust_bep_rename_root_hash_to_is_bep_30.sql
@@ -1,0 +1,1 @@
+ALTER TABLE torrust_torrents CHANGE COLUMN root_hash is_bep_30 BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/mysql/20240305120015_torrust_add_independent_root_hash_field.sql
+++ b/migrations/mysql/20240305120015_torrust_add_independent_root_hash_field.sql
@@ -1,0 +1,4 @@
+ALTER TABLE torrust_torrents ADD COLUMN root_hash LONGTEXT;
+
+-- Make `pieces` nullable. BEP 30 torrents does have this field.
+ALTER TABLE torrust_torrents MODIFY COLUMN pieces LONGTEXT;

--- a/migrations/sqlite3/20240305110750_torrust_bep_rename_root_hash_to_is_bep_30.sql
+++ b/migrations/sqlite3/20240305110750_torrust_bep_rename_root_hash_to_is_bep_30.sql
@@ -1,0 +1,1 @@
+ALTER TABLE torrust_torrents RENAME COLUMN root_hash TO is_bep_30;

--- a/migrations/sqlite3/20240305120015_torrust_add_independent_root_hash_field.sql
+++ b/migrations/sqlite3/20240305120015_torrust_add_independent_root_hash_field.sql
@@ -1,0 +1,77 @@
+-- add field `root_hash` and make `pieces` nullable
+CREATE TABLE
+    "torrust_torrents_new" (
+        "torrent_id" INTEGER NOT NULL,
+        "uploader_id" INTEGER NOT NULL,
+        "category_id" INTEGER,
+        "info_hash" TEXT NOT NULL UNIQUE,
+        "size" INTEGER NOT NULL,
+        "name" TEXT NOT NULL,
+        "pieces" TEXT,
+        "root_hash" TEXT,
+        "piece_length" INTEGER NOT NULL,
+        "private" BOOLEAN DEFAULT NULL,
+        "is_bep_30" INT NOT NULL DEFAULT 0,
+        "date_uploaded" TEXT NOT NULL,
+        "source" TEXT DEFAULT NULL,
+        "comment" TEXT,
+        "creation_date" BIGINT,
+        "created_by" TEXT,
+        "encoding" TEXT,
+        FOREIGN KEY ("uploader_id") REFERENCES "torrust_users" ("user_id") ON DELETE CASCADE,
+        FOREIGN KEY ("category_id") REFERENCES "torrust_categories" ("category_id") ON DELETE SET NULL,
+        PRIMARY KEY ("torrent_id" AUTOINCREMENT)
+    );
+
+-- Step 2: Copy data from the old table to the new table
+INSERT INTO
+    torrust_torrents_new (
+        torrent_id,
+        uploader_id,
+        category_id,
+        info_hash,
+        size,
+        name,
+        pieces,
+        piece_length,
+        private,
+        root_hash,
+        date_uploaded,
+        source,
+        comment,
+        creation_date,
+        created_by,
+        encoding
+    )
+SELECT
+    torrent_id,
+    uploader_id,
+    category_id,
+    info_hash,
+    size,
+    name,
+    CASE
+        WHEN is_bep_30 = 0 THEN pieces
+        ELSE NULL
+    END,
+    piece_length,
+    private,
+    CASE
+        WHEN is_bep_30 = 1 THEN pieces
+        ELSE NULL
+    END,
+    date_uploaded,
+    source,
+    comment,
+    creation_date,
+    created_by,
+    encoding
+FROM
+    torrust_torrents;
+
+-- Step 3: Drop the old table
+DROP TABLE torrust_torrents;
+
+-- Step 4: Rename the new table to the original name
+ALTER TABLE torrust_torrents_new
+RENAME TO torrust_torrents;

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -438,8 +438,9 @@ impl Database for Mysql {
         // start db transaction
         let mut tx = conn.begin().await.map_err(|_| database::Error::Error)?;
 
-        // torrent file can only hold a pieces key or a root hash key: http://www.bittorrent.org/beps/bep_0030.html
-        let (pieces, root_hash): (String, bool) = if let Some(pieces) = &torrent.info.pieces {
+        // torrent file can only hold a `pieces` key or a `root hash` key
+        // BEP 30: http://www.bittorrent.org/beps/bep_0030.html
+        let (pieces, is_bep_30): (String, bool) = if let Some(pieces) = &torrent.info.pieces {
             (from_bytes(pieces.as_ref()), false)
         } else {
             let root_hash = torrent.info.root_hash.as_ref().ok_or(database::Error::Error)?;
@@ -457,7 +458,7 @@ impl Database for Mysql {
             pieces,
             piece_length,
             private,
-            root_hash,
+            is_bep_30,
             `source`,
             comment,
             date_uploaded,
@@ -474,7 +475,7 @@ impl Database for Mysql {
         .bind(pieces)
         .bind(torrent.info.piece_length)
         .bind(torrent.info.private)
-        .bind(root_hash)
+        .bind(is_bep_30)
         .bind(torrent.info.source.clone())
         .bind(torrent.comment.clone())
         .bind(torrent.creation_date)

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -428,13 +428,17 @@ impl Database for Sqlite {
         // start db transaction
         let mut tx = conn.begin().await.map_err(|_| database::Error::Error)?;
 
-        // torrent file can only hold a pieces key or a root hash key: http://www.bittorrent.org/beps/bep_0030.html
-        let (pieces, is_bep_30): (String, bool) = if let Some(pieces) = &torrent.info.pieces {
-            (from_bytes(pieces.as_ref()), false)
-        } else {
-            let root_hash = torrent.info.root_hash.as_ref().ok_or(database::Error::Error)?;
-            (root_hash.to_string(), true)
-        };
+        // BEP 30: <http://www.bittorrent.org/beps/bep_0030.html>.
+        // Torrent file can only hold a `pieces` key or a `root hash` key
+        let is_bep_30 = !matches!(&torrent.info.pieces, Some(_pieces));
+
+        let pieces = torrent.info.pieces.as_ref().map(|pieces| from_bytes(pieces.as_ref()));
+
+        let root_hash = torrent
+            .info
+            .root_hash
+            .as_ref()
+            .map(|root_hash| from_bytes(root_hash.as_ref()));
 
         // add torrent
         let torrent_id = query(
@@ -445,6 +449,7 @@ impl Database for Sqlite {
             size,
             name,
             pieces,
+            root_hash,
             piece_length,
             private,
             is_bep_30,
@@ -454,7 +459,7 @@ impl Database for Sqlite {
             creation_date,
             created_by,
             `encoding`
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%S',DATETIME('now', 'utc')), ?, ?, ?)",
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%S',DATETIME('now', 'utc')), ?, ?, ?)",
         )
         .bind(uploader_id)
         .bind(metadata.category_id)
@@ -462,6 +467,7 @@ impl Database for Sqlite {
         .bind(torrent.file_size())
         .bind(torrent.info.name.to_string())
         .bind(pieces)
+        .bind(root_hash)
         .bind(torrent.info.piece_length)
         .bind(torrent.info.private)
         .bind(is_bep_30)

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -429,7 +429,7 @@ impl Database for Sqlite {
         let mut tx = conn.begin().await.map_err(|_| database::Error::Error)?;
 
         // torrent file can only hold a pieces key or a root hash key: http://www.bittorrent.org/beps/bep_0030.html
-        let (pieces, root_hash): (String, bool) = if let Some(pieces) = &torrent.info.pieces {
+        let (pieces, is_bep_30): (String, bool) = if let Some(pieces) = &torrent.info.pieces {
             (from_bytes(pieces.as_ref()), false)
         } else {
             let root_hash = torrent.info.root_hash.as_ref().ok_or(database::Error::Error)?;
@@ -447,7 +447,7 @@ impl Database for Sqlite {
             pieces,
             piece_length,
             private,
-            root_hash,
+            is_bep_30,
             `source`,
             comment,
             date_uploaded,
@@ -464,7 +464,7 @@ impl Database for Sqlite {
         .bind(pieces)
         .bind(torrent.info.piece_length)
         .bind(torrent.info.private)
-        .bind(root_hash)
+        .bind(is_bep_30)
         .bind(torrent.info.source.clone())
         .bind(torrent.comment.clone())
         .bind(torrent.creation_date)

--- a/src/models/torrent_file.rs
+++ b/src/models/torrent_file.rs
@@ -81,7 +81,7 @@ impl Torrent {
             &db_torrent.name,
             db_torrent.piece_length,
             db_torrent.private,
-            db_torrent.root_hash,
+            db_torrent.is_bep_30,
             &db_torrent.pieces,
             torrent_files,
         );
@@ -235,7 +235,7 @@ impl TorrentInfoDictionary {
     /// - The `pieces` field is not a valid hex string.
     /// - For single files torrents the `TorrentFile` path is empty.
     #[must_use]
-    pub fn with(name: &str, piece_length: i64, private: Option<u8>, root_hash: i64, pieces: &str, files: &[TorrentFile]) -> Self {
+    pub fn with(name: &str, piece_length: i64, private: Option<u8>, is_bep_30: i64, pieces: &str, files: &[TorrentFile]) -> Self {
         let mut info_dict = Self {
             name: name.to_string(),
             pieces: None,
@@ -250,8 +250,8 @@ impl TorrentInfoDictionary {
         };
 
         // a torrent file has a root hash or a pieces key, but not both.
-        if root_hash > 0 {
-            // If `root_hash` is true the `pieces` field contains the `root hash`
+        if is_bep_30 > 0 {
+            // If `is_bep_30` is true the `pieces` field contains the `root hash`
             info_dict.root_hash = Some(pieces.to_owned());
         } else {
             let buffer = into_bytes(pieces).expect("variable `torrent_info.pieces` is not a valid hex string");
@@ -334,7 +334,7 @@ pub struct DbTorrent {
     pub piece_length: i64,
     #[serde(default)]
     pub private: Option<u8>,
-    pub root_hash: i64,
+    pub is_bep_30: i64,
     pub comment: Option<String>,
     pub creation_date: Option<i64>,
     pub created_by: Option<String>,

--- a/src/models/torrent_file.rs
+++ b/src/models/torrent_file.rs
@@ -1,3 +1,4 @@
+use log::error;
 use serde::{Deserialize, Serialize};
 use serde_bencode::ser;
 use serde_bytes::ByteBuf;
@@ -77,12 +78,31 @@ impl Torrent {
         torrent_http_seed_urls: Vec<String>,
         torrent_nodes: Vec<(String, i64)>,
     ) -> Self {
+        let pieces_or_root_hash = if db_torrent.is_bep_30 == 0 {
+            match &db_torrent.pieces {
+                Some(pieces) => pieces.clone(),
+                None => {
+                    error!("Invalid torrent #{}. Null `pieces` in database", db_torrent.torrent_id);
+                    String::new()
+                }
+            }
+        } else {
+            // A BEP-30 torrent
+            match &db_torrent.root_hash {
+                Some(root_hash) => root_hash.clone(),
+                None => {
+                    error!("Invalid torrent #{}. Null `root_hash` in database", db_torrent.torrent_id);
+                    String::new()
+                }
+            }
+        };
+
         let info_dict = TorrentInfoDictionary::with(
             &db_torrent.name,
             db_torrent.piece_length,
             db_torrent.private,
             db_torrent.is_bep_30,
-            &db_torrent.pieces,
+            &pieces_or_root_hash,
             torrent_files,
         );
 
@@ -235,7 +255,14 @@ impl TorrentInfoDictionary {
     /// - The `pieces` field is not a valid hex string.
     /// - For single files torrents the `TorrentFile` path is empty.
     #[must_use]
-    pub fn with(name: &str, piece_length: i64, private: Option<u8>, is_bep_30: i64, pieces: &str, files: &[TorrentFile]) -> Self {
+    pub fn with(
+        name: &str,
+        piece_length: i64,
+        private: Option<u8>,
+        is_bep_30: i64,
+        pieces_or_root_hash: &str,
+        files: &[TorrentFile],
+    ) -> Self {
         let mut info_dict = Self {
             name: name.to_string(),
             pieces: None,
@@ -249,13 +276,13 @@ impl TorrentInfoDictionary {
             source: None,
         };
 
-        // a torrent file has a root hash or a pieces key, but not both.
-        if is_bep_30 > 0 {
-            // If `is_bep_30` is true the `pieces` field contains the `root hash`
-            info_dict.root_hash = Some(pieces.to_owned());
-        } else {
-            let buffer = into_bytes(pieces).expect("variable `torrent_info.pieces` is not a valid hex string");
+        // BEP 30: <http://www.bittorrent.org/beps/bep_0030.html>.
+        // Torrent file can only hold a `pieces` key or a `root hash` key
+        if is_bep_30 == 0 {
+            let buffer = into_bytes(pieces_or_root_hash).expect("variable `torrent_info.pieces` is not a valid hex string");
             info_dict.pieces = Some(ByteBuf::from(buffer));
+        } else {
+            info_dict.root_hash = Some(pieces_or_root_hash.to_owned());
         }
 
         // either set the single file or the multiple files information
@@ -298,20 +325,20 @@ impl TorrentInfoDictionary {
         }
     }
 
-    /// It returns the root hash as a `i64` value.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if the root hash cannot be converted into a
-    /// `i64` value.
+    /// torrent file can only hold a pieces key or a root hash key:
+    /// [BEP 39](http://www.bittorrent.org/beps/bep_0030.html)
     #[must_use]
-    pub fn get_root_hash_as_i64(&self) -> i64 {
+    pub fn get_root_hash_as_string(&self) -> String {
         match &self.root_hash {
-            None => 0i64,
-            Some(root_hash) => root_hash
-                .parse::<i64>()
-                .expect("variable `root_hash` cannot be converted into a `i64`"),
+            None => String::new(),
+            Some(root_hash) => root_hash.clone(),
         }
+    }
+
+    /// It returns true if the torrent is a BEP-30 torrent.
+    #[must_use]
+    pub fn is_bep_30(&self) -> bool {
+        self.root_hash.is_some()
     }
 
     #[must_use]
@@ -330,7 +357,8 @@ pub struct DbTorrent {
     pub torrent_id: i64,
     pub info_hash: String,
     pub name: String,
-    pub pieces: String,
+    pub pieces: Option<String>,
+    pub root_hash: Option<String>,
     pub piece_length: i64,
     #[serde(default)]
     pub private: Option<u8>,

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -14,7 +14,8 @@ pub struct CreateTorrentRequest {
     pub pieces: String,
     pub piece_length: i64,
     pub private: Option<u8>,
-    pub root_hash: i64, // True (1) if it's a BEP 30 torrent.
+    /// True (1) if it's a BEP 30 torrent.
+    pub is_bep_30: i64,
     pub files: Vec<TorrentFile>,
     // Other fields of the root level metainfo dictionary
     pub announce_urls: Vec<Vec<String>>,
@@ -58,7 +59,7 @@ impl CreateTorrentRequest {
             &self.name,
             self.piece_length,
             self.private,
-            self.root_hash,
+            self.is_bep_30,
             &self.pieces,
             &self.files,
         )
@@ -92,7 +93,7 @@ pub fn generate_random_torrent(id: Uuid) -> Torrent {
         pieces: sha1(&file_contents),
         piece_length: 16384,
         private: None,
-        root_hash: 0,
+        is_bep_30: 0,
         files: torrent_files,
         announce_urls: torrent_announce_urls,
         comment: None,

--- a/src/services/torrent_file.rs
+++ b/src/services/torrent_file.rs
@@ -11,7 +11,7 @@ use crate::services::hasher::sha1;
 pub struct CreateTorrentRequest {
     // The `info` dictionary fields
     pub name: String,
-    pub pieces: String,
+    pub pieces_or_root_hash: String,
     pub piece_length: i64,
     pub private: Option<u8>,
     /// True (1) if it's a BEP 30 torrent.
@@ -60,7 +60,7 @@ impl CreateTorrentRequest {
             self.piece_length,
             self.private,
             self.is_bep_30,
-            &self.pieces,
+            &self.pieces_or_root_hash,
             &self.files,
         )
     }
@@ -90,7 +90,7 @@ pub fn generate_random_torrent(id: Uuid) -> Torrent {
 
     let create_torrent_req = CreateTorrentRequest {
         name: format!("file-{id}.txt"),
-        pieces: sha1(&file_contents),
+        pieces_or_root_hash: sha1(&file_contents),
         piece_length: 16384,
         private: None,
         is_bep_30: 0,

--- a/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
+++ b/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
@@ -26,7 +26,7 @@ pub struct TorrentRecordV2 {
     pub pieces: String,
     pub piece_length: i64,
     pub private: Option<u8>,
-    pub root_hash: i64,
+    pub is_bep_30: i64,
     pub date_uploaded: String,
 }
 
@@ -43,7 +43,7 @@ impl TorrentRecordV2 {
             pieces: torrent_info.get_pieces_as_string(),
             piece_length: torrent_info.piece_length,
             private: torrent_info.private,
-            root_hash: torrent_info.get_root_hash_as_i64(),
+            is_bep_30: torrent_info.get_root_hash_as_i64(),
             date_uploaded: convert_timestamp_to_datetime(torrent.upload_date),
         }
     }
@@ -196,7 +196,7 @@ impl SqliteDatabaseV2_0_0 {
                 pieces,
                 piece_length,
                 private,
-                root_hash,
+                is_bep_30,
                 date_uploaded
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
@@ -209,7 +209,7 @@ impl SqliteDatabaseV2_0_0 {
         .bind(torrent.pieces.clone())
         .bind(torrent.piece_length)
         .bind(torrent.private.unwrap_or(0))
-        .bind(torrent.root_hash)
+        .bind(torrent.is_bep_30)
         .bind(torrent.date_uploaded.clone())
         .execute(&self.pool)
         .await

--- a/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
+++ b/src/upgrades/from_v1_0_0_to_v2_0_0/databases/sqlite_v2_0_0.rs
@@ -23,7 +23,8 @@ pub struct TorrentRecordV2 {
     pub info_hash: String,
     pub size: i64,
     pub name: String,
-    pub pieces: String,
+    pub pieces: Option<String>,
+    pub root_hash: Option<String>,
     pub piece_length: i64,
     pub private: Option<u8>,
     pub is_bep_30: i64,
@@ -40,10 +41,11 @@ impl TorrentRecordV2 {
             info_hash: torrent.info_hash.clone(),
             size: torrent.file_size,
             name: torrent_info.name.clone(),
-            pieces: torrent_info.get_pieces_as_string(),
+            pieces: Some(torrent_info.get_pieces_as_string()),
+            root_hash: Some(torrent_info.get_root_hash_as_string()),
             piece_length: torrent_info.piece_length,
             private: torrent_info.private,
-            is_bep_30: torrent_info.get_root_hash_as_i64(),
+            is_bep_30: i64::from(torrent_info.is_bep_30()),
             date_uploaded: convert_timestamp_to_datetime(torrent.upload_date),
         }
     }

--- a/tests/upgrades/from_v1_0_0_to_v2_0_0/transferrer_testers/torrent_transferrer_tester.rs
+++ b/tests/upgrades/from_v1_0_0_to_v2_0_0/transferrer_testers/torrent_transferrer_tester.rs
@@ -112,14 +112,15 @@ impl TorrentTester {
         assert_eq!(imported_torrent.info_hash, torrent.info_hash);
         assert_eq!(imported_torrent.size, torrent.file_size);
         assert_eq!(imported_torrent.name, torrent_file.info.name);
-        assert_eq!(imported_torrent.pieces, torrent_file.info.get_pieces_as_string());
+        assert_eq!(imported_torrent.pieces, Some(torrent_file.info.get_pieces_as_string()));
+        assert_eq!(imported_torrent.root_hash, None);
         assert_eq!(imported_torrent.piece_length, torrent_file.info.piece_length);
         if torrent_file.info.private.is_none() {
             assert_eq!(imported_torrent.private, Some(0));
         } else {
             assert_eq!(imported_torrent.private, torrent_file.info.private);
         }
-        assert_eq!(imported_torrent.is_bep_30, torrent_file.info.get_root_hash_as_i64());
+        assert_eq!(imported_torrent.is_bep_30, i64::from(torrent_file.info.is_bep_30()));
         assert_eq!(
             imported_torrent.date_uploaded,
             convert_timestamp_to_datetime(torrent.upload_date)

--- a/tests/upgrades/from_v1_0_0_to_v2_0_0/transferrer_testers/torrent_transferrer_tester.rs
+++ b/tests/upgrades/from_v1_0_0_to_v2_0_0/transferrer_testers/torrent_transferrer_tester.rs
@@ -119,7 +119,7 @@ impl TorrentTester {
         } else {
             assert_eq!(imported_torrent.private, torrent_file.info.private);
         }
-        assert_eq!(imported_torrent.root_hash, torrent_file.info.get_root_hash_as_i64());
+        assert_eq!(imported_torrent.is_bep_30, torrent_file.info.get_root_hash_as_i64());
         assert_eq!(
             imported_torrent.date_uploaded,
             convert_timestamp_to_datetime(torrent.upload_date)


### PR DESCRIPTION
Refactor BEP 30 implementation to make it clearer and simplify implementation.

- [x] Rename table field `torrust_torrents::root_hash` to `is_bep_30`. It's not the `root hash` value in BEP 30. It's a flag for BEP 30 torrents.
- [x] Don't reuse `torrust_torrents::pieces` field for BEP 30 torrents. Add a new field `root_hash`.

BEP 30: https://www.bittorrent.org/beps/bep_0030.html