### PR TITLE
Feature: inlude the canonical info hash group in the torrent details response

### DIFF
--- a/share/default/config/index.development.sqlite3.toml
+++ b/share/default/config/index.development.sqlite3.toml
@@ -1,4 +1,4 @@
-log_level = "debug"
+log_level = "info"
 
 [website]
 name = "Torrust"

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -6,6 +6,7 @@ use crate::databases::database::Category as DatabaseCategory;
 use crate::models::torrent::TorrentListing;
 use crate::models::torrent_file::TorrentFile;
 use crate::models::torrent_tag::TorrentTag;
+use crate::services::torrent::CanonicalInfoHashGroup;
 
 pub enum OkResponses {
     TokenResponse(TokenResponse),
@@ -67,11 +68,16 @@ pub struct TorrentResponse {
     pub creation_date: Option<i64>,
     pub created_by: Option<String>,
     pub encoding: Option<String>,
+    pub canonical_info_hash_group: Vec<String>,
 }
 
 impl TorrentResponse {
     #[must_use]
-    pub fn from_listing(torrent_listing: TorrentListing, category: Option<DatabaseCategory>) -> TorrentResponse {
+    pub fn from_listing(
+        torrent_listing: TorrentListing,
+        category: Option<DatabaseCategory>,
+        canonical_info_hash_group: &CanonicalInfoHashGroup,
+    ) -> TorrentResponse {
         TorrentResponse {
             torrent_id: torrent_listing.torrent_id,
             uploader: torrent_listing.uploader,
@@ -92,6 +98,11 @@ impl TorrentResponse {
             creation_date: torrent_listing.creation_date,
             created_by: torrent_listing.created_by,
             encoding: torrent_listing.encoding,
+            canonical_info_hash_group: canonical_info_hash_group
+                .original_info_hashes
+                .iter()
+                .map(super::info_hash::InfoHash::to_hex_string)
+                .collect(),
         }
     }
 

--- a/tests/common/contexts/torrent/responses.rs
+++ b/tests/common/contexts/torrent/responses.rs
@@ -72,6 +72,7 @@ pub struct TorrentDetails {
     pub creation_date: Option<i64>,
     pub created_by: Option<String>,
     pub encoding: Option<String>,
+    pub canonical_info_hash_group: Vec<String>,
 }
 
 #[derive(Deserialize, PartialEq, Debug)]

--- a/tests/e2e/web/api/v1/contexts/torrent/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/contract.rs
@@ -196,11 +196,6 @@ mod for_guests {
                 length: test_torrent.file_info.content_size,
                 md5sum: None,
             }],
-            // code-review: why is this duplicated? It seems that is adding the
-            // same tracker twice because first it adds all trackers and then
-            // it adds the tracker with the personal announce url, if the user
-            // is logged in. If the user is not logged in, it adds the default
-            // tracker again, and it ends up with two trackers.
             trackers: vec![tracker_url.clone()],
             magnet_link: format!(
                 // cspell:disable-next-line

--- a/tests/e2e/web/api/v1/contexts/torrent/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/contract.rs
@@ -197,7 +197,7 @@ mod for_guests {
                 md5sum: None,
             }],
             // code-review: why is this duplicated? It seems that is adding the
-            // same tracker twice because first ti adds all trackers and then
+            // same tracker twice because first it adds all trackers and then
             // it adds the tracker with the personal announce url, if the user
             // is logged in. If the user is not logged in, it adds the default
             // tracker again, and it ends up with two trackers.
@@ -215,6 +215,7 @@ mod for_guests {
             creation_date: test_torrent.file_info.creation_date,
             created_by: test_torrent.file_info.created_by.clone(),
             encoding: test_torrent.file_info.encoding.clone(),
+            canonical_info_hash_group: vec![test_torrent.file_info.info_hash.to_lowercase()],
         };
 
         assert_expected_torrent_details(&torrent_details_response.data, &expected_torrent);


### PR DESCRIPTION
Add to the responses (torrent details and after updating a torrent) the list of info-hashes that belong to the same canonical info-hash. Table `torrust_torrent_info_hashes`

```sql
CREATE TABLE "torrust_torrent_info_hashes" (
	"info_hash"	TEXT NOT NULL,
	"canonical_info_hash"	TEXT NOT NULL,
	"original_is_known"	BOOLEAN NOT NULL,
	PRIMARY KEY("info_hash"),
	FOREIGN KEY("canonical_info_hash") REFERENCES "torrust_torrents"("info_hash") ON DELETE CASCADE
);
```

New response for torrent details:

```json
{
    "data": {
        "torrent_id": 2,
        "uploader": "admin",
        "info_hash": "0c90fbf036e28370c1ec773401bc7620146b1d48",
        "title": "Test 01",
        "description": "Test 01",
        "category": {
            "id": 5,
            "category_id": 5,
            "name": "software",
            "num_torrents": 1
        },
        "upload_date": "2024-03-05 16:05:00",
        "file_size": 602515,
        "seeders": 0,
        "leechers": 0,
        "files": [
            {
                "path": [
                    "mandelbrot_set_01"
                ],
                "length": 602515,
                "md5sum": null
            }
        ],
        "trackers": [
            "udp://localhost:6969"
        ],
        "magnet_link": "magnet:?xt=urn:btih:0c90fbf036e28370c1ec773401bc7620146b1d48&dn=Test%2001&tr=udp%3A%2F%2Flocalhost%3A6969",
        "tags": [],
        "name": "mandelbrot_set_01",
        "comment": "Mandelbrot Set 01",
        "creation_date": 1687937540,
        "created_by": "Transmission/3.00 (bb6b5a062e)",
        "encoding": "UTF-8",
        "canonical_info_hash_group": [
            "d5eaff5bc75ed274da7c5294de3f6641dc0a90ce",
            "e126f473a9dee89217d7ae5982f9b21490ed2c3f"
        ]
    }
}
```

Notice the new field `canonical_info_hash_group`.

Both the `d5eaff5bc75ed274da7c5294de3f6641dc0a90ce` and `e126f473a9dee89217d7ae5982f9b21490ed2c3f` were uploaded torrents that produced the same canonical info-hash `0c90fbf036e28370c1ec773401bc7620146b1d48`