### PR TITLE
Refactor: rename fields in upload torrent response

### DIFF
--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -45,8 +45,8 @@ pub struct AddTorrentRequest {
 
 pub struct AddTorrentResponse {
     pub torrent_id: TorrentId,
+    pub canonical_info_hash: String,
     pub info_hash: String,
-    pub original_info_hash: String,
 }
 
 /// User request to generate a torrent listing.
@@ -172,8 +172,8 @@ impl Index {
 
         Ok(AddTorrentResponse {
             torrent_id,
-            info_hash: torrent.canonical_info_hash_hex(),
-            original_info_hash: original_info_hash.to_string(),
+            canonical_info_hash: torrent.canonical_info_hash_hex(),
+            info_hash: original_info_hash.to_string(),
         })
     }
 

--- a/src/web/api/server/v1/contexts/torrent/responses.rs
+++ b/src/web/api/server/v1/contexts/torrent/responses.rs
@@ -11,8 +11,8 @@ use crate::web::api::server::v1::responses::OkResponseData;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NewTorrentResponseData {
     pub torrent_id: TorrentId,
+    pub canonical_info_hash: String,
     pub info_hash: String,
-    pub original_info_hash: String,
 }
 
 /// Response after successfully uploading a new torrent.
@@ -20,8 +20,8 @@ pub fn new_torrent_response(add_torrent_response: &AddTorrentResponse) -> Json<O
     Json(OkResponseData {
         data: NewTorrentResponseData {
             torrent_id: add_torrent_response.torrent_id,
+            canonical_info_hash: add_torrent_response.canonical_info_hash.clone(),
             info_hash: add_torrent_response.info_hash.clone(),
-            original_info_hash: add_torrent_response.original_info_hash.clone(),
         },
     })
 }

--- a/tests/common/contexts/torrent/responses.rs
+++ b/tests/common/contexts/torrent/responses.rs
@@ -103,6 +103,7 @@ pub struct UploadedTorrentResponse {
 #[derive(Deserialize, PartialEq, Debug)]
 pub struct UploadedTorrent {
     pub torrent_id: Id,
+    pub canonical_info_hash: String,
     pub info_hash: String,
 }
 

--- a/tests/e2e/web/api/v1/contexts/torrent/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/contract.rs
@@ -504,7 +504,7 @@ mod for_authenticated_users {
             let uploaded_torrent_response: UploadedTorrentResponse = serde_json::from_str(&response.body).unwrap();
 
             assert_eq!(
-                uploaded_torrent_response.data.info_hash.to_lowercase(),
+                uploaded_torrent_response.data.canonical_info_hash.to_lowercase(),
                 info_hash.to_lowercase()
             );
             assert!(response.is_json_and_ok());

--- a/tests/e2e/web/api/v1/contexts/torrent/steps.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/steps.rs
@@ -50,7 +50,7 @@ pub async fn upload_test_torrent(client: &Client, test_torrent: &TestTorrent) ->
     }
 
     let uploaded_torrent_response: UploadedTorrentResponse = serde_json::from_str(&response.body).unwrap();
-    let canonical_info_hash_hex = uploaded_torrent_response.data.info_hash.to_lowercase();
+    let canonical_info_hash_hex = uploaded_torrent_response.data.canonical_info_hash.to_lowercase();
 
     let canonical_info_hash = InfoHash::from_str(&canonical_info_hash_hex)
         .unwrap_or_else(|_| panic!("Invalid info-hash in database: {canonical_info_hash_hex}"));


### PR DESCRIPTION
To match the latest changes in the database. 

From:

```json
{
    "data": {
        "torrent_id": 12,
        "info_hash": "c01f910ff0cc2a1b8c7a1f6ab948377604d8c464",
        "original_info_hash": "dc0c6be689b28696319263ef27f9df4da8ded0a2"
    }
}
```

To:

```
{
    "data": {
        "torrent_id": 12,
        "canonical_info_hash": "c01f910ff0cc2a1b8c7a1f6ab948377604d8c464",
        "info_hash": "dc0c6be689b28696319263ef27f9df4da8ded0a2"
    }
}
```