### PR TITLE
Refactor handlers to inject only the needed dependencies

### DIFF
--- a/src/web/api/server/v1/contexts/category/handlers.rs
+++ b/src/web/api/server/v1/contexts/category/handlers.rs
@@ -4,10 +4,12 @@ use std::sync::Arc;
 
 use axum::extract::{self, State};
 use axum::response::{IntoResponse, Json, Response};
+use axum::Extension;
 
 use super::forms::{AddCategoryForm, DeleteCategoryForm};
 use super::responses::{added_category, deleted_category, Category};
 use crate::common::AppData;
+use crate::services::category::DbCategoryRepository;
 use crate::web::api::server::v1::extractors::user_id::ExtractLoggedInUser;
 use crate::web::api::server::v1::responses::{self};
 
@@ -25,8 +27,8 @@ use crate::web::api::server::v1::responses::{self};
 ///
 /// It returns an error if there is a database error.
 #[allow(clippy::unused_async)]
-pub async fn get_all_handler(State(app_data): State<Arc<AppData>>) -> Response {
-    match app_data.category_repository.get_all().await {
+pub async fn get_all_handler(Extension(category_repository): Extension<Arc<DbCategoryRepository>>) -> Response {
+    match category_repository.get_all().await {
         Ok(categories) => {
             let categories: Vec<Category> = categories.into_iter().map(Category::from).collect();
             Json(responses::OkResponseData { data: categories }).into_response()

--- a/src/web/api/server/v1/contexts/category/routes.rs
+++ b/src/web/api/server/v1/contexts/category/routes.rs
@@ -4,15 +4,16 @@
 use std::sync::Arc;
 
 use axum::routing::{delete, get, post};
-use axum::Router;
+use axum::{Extension, Router};
 
 use super::handlers::{add_handler, delete_handler, get_all_handler};
 use crate::common::AppData;
 
 /// Routes for the [`category`](crate::web::api::server::v1::contexts::category) API context.
-pub fn router(app_data: Arc<AppData>) -> Router {
+pub fn router(app_data: &Arc<AppData>) -> Router {
     Router::new()
-        .route("/", get(get_all_handler).with_state(app_data.clone()))
+        .route("/", get(get_all_handler))
         .route("/", post(add_handler).with_state(app_data.clone()))
-        .route("/", delete(delete_handler).with_state(app_data))
+        .route("/", delete(delete_handler).with_state(app_data.clone()))
+        .layer(Extension(app_data.category_repository.clone()))
 }

--- a/src/web/api/server/v1/routes.rs
+++ b/src/web/api/server/v1/routes.rs
@@ -34,7 +34,7 @@ pub fn router(app_data: Arc<AppData>) -> Router {
         .route("/", get(redirect_to_about))
         .nest("/user", user::routes::router(app_data.clone()))
         .nest("/about", about::routes::router(app_data.clone()))
-        .nest("/category", category::routes::router(app_data.clone()))
+        .nest("/category", category::routes::router(&app_data.clone()))
         .nest("/tag", tag::routes::router_for_single_resources(app_data.clone()))
         .nest("/tags", tag::routes::router_for_multiple_resources(app_data.clone()))
         .nest("/settings", settings::routes::router(app_data.clone()))


### PR DESCRIPTION
@mario-nt and I have been discussing handlers. We think:

- They should be thinner.
- We could inject only the dependencies they need, so the body is clearer and also we make it explicit what are the handler dependencies.

This is an example of the second point (refactor), just to show how it could be done.

Refer to the discussion for more info: https://github.com/torrust/torrust-index/discussions/524