### PR TITLE
Improve tracker statistics importation

### DIFF
--- a/migrations/mysql/20240312130530_torrust_add_update_data_to_tracker_stats.sql
+++ b/migrations/mysql/20240312130530_torrust_add_update_data_to_tracker_stats.sql
@@ -1,0 +1,4 @@
+-- New field to track when stats were updated from the tracker
+ALTER TABLE torrust_torrent_tracker_stats ADD COLUMN updated_at DATETIME DEFAULT NULL;
+UPDATE torrust_torrent_tracker_stats SET updated_at = '1000-01-01 00:00:00';
+ALTER TABLE torrust_torrent_tracker_stats MODIFY COLUMN updated_at DATETIME NOT NULL;

--- a/migrations/sqlite3/20240312130530_torrust_add_update_data_to_tracker_stats.sql
+++ b/migrations/sqlite3/20240312130530_torrust_add_update_data_to_tracker_stats.sql
@@ -1,0 +1,2 @@
+-- New field to track when stats were updated from the tracker
+ALTER TABLE torrust_torrent_tracker_stats ADD COLUMN updated_at TEXT DEFAULT "1000-01-01 00:00:00";

--- a/src/console/cronjobs/tracker_statistics_importer.rs
+++ b/src/console/cronjobs/tracker_statistics_importer.rs
@@ -83,6 +83,15 @@ pub fn start(
 
         info!("Tracker statistics importer cronjob starting ...");
 
+        // code-review: we set an execution interval to avoid intense polling to
+        // the database. If we remove the interval we would be constantly
+        // queering if there are torrent stats pending to update, unless there
+        // are torrents to update. Maybe we should only sleep for 100 milliseconds
+        // if we did not update any torrents in the latest execution.
+        // With this current limit we can only import 50 torrent stats every 100
+        // milliseconds which is 500 torrents per second (1800000 torrents per hour).
+        // If the tracker can handle a request in 100 milliseconds.
+
         let execution_interval_in_milliseconds = 100;
         let execution_interval_duration = std::time::Duration::from_millis(execution_interval_in_milliseconds);
         let mut execution_interval = tokio::time::interval(execution_interval_duration);

--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use chrono::NaiveDateTime;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::databases::mysql::Mysql;
@@ -291,6 +291,13 @@ pub trait Database: Sync + Send {
 
     /// Get all torrents as `Vec<TorrentCompact>`.
     async fn get_all_torrents_compact(&self) -> Result<Vec<TorrentCompact>, Error>;
+
+    /// Get torrents whose stats have not been imported from the tracker at least since a given datetime.
+    async fn get_torrents_with_stats_not_updated_since(
+        &self,
+        datetime: DateTime<Utc>,
+        limit: i64,
+    ) -> Result<Vec<TorrentCompact>, Error>;
 
     /// Update a torrent's title with `torrent_id` and `title`.
     async fn update_torrent_title(&self, torrent_id: i64, title: &str) -> Result<(), Error>;

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -20,7 +20,7 @@ use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserId, UserProfile};
 use crate::services::torrent::{CanonicalInfoHashGroup, DbTorrentInfoHash};
-use crate::utils::clock;
+use crate::utils::clock::{self, datetime_now};
 use crate::utils::hex::from_bytes;
 
 pub struct Mysql {
@@ -1055,11 +1055,12 @@ impl Database for Mysql {
         seeders: i64,
         leechers: i64,
     ) -> Result<(), database::Error> {
-        query("REPLACE INTO torrust_torrent_tracker_stats (torrent_id, tracker_url, seeders, leechers) VALUES (?, ?, ?, ?)")
+        query("REPLACE INTO torrust_torrent_tracker_stats (torrent_id, tracker_url, seeders, leechers, updated_at) VALUES (?, ?, ?, ?, ?)")
             .bind(torrent_id)
             .bind(tracker_url)
             .bind(seeders)
             .bind(leechers)
+            .bind(datetime_now())
             .execute(&self.pool)
             .await
             .map(|_| ())

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use chrono::NaiveDateTime;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use sqlx::mysql::{MySqlConnectOptions, MySqlPoolOptions};
 use sqlx::{query, query_as, Acquire, ConnectOptions, MySqlPool};
 
@@ -20,7 +20,7 @@ use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserId, UserProfile};
 use crate::services::torrent::{CanonicalInfoHashGroup, DbTorrentInfoHash};
-use crate::utils::clock::{self, datetime_now};
+use crate::utils::clock::{self, datetime_now, DATETIME_FORMAT};
 use crate::utils::hex::from_bytes;
 
 pub struct Mysql {
@@ -882,6 +882,27 @@ impl Database for Mysql {
             .fetch_all(&self.pool)
             .await
             .map_err(|_| database::Error::Error)
+    }
+
+    async fn get_torrents_with_stats_not_updated_since(
+        &self,
+        datetime: DateTime<Utc>,
+        limit: i64,
+    ) -> Result<Vec<TorrentCompact>, database::Error> {
+        query_as::<_, TorrentCompact>(
+            "SELECT tt.torrent_id, tt.info_hash
+             FROM torrust_torrents tt
+             LEFT JOIN torrust_torrent_tracker_stats tts ON tt.torrent_id = tts.torrent_id
+             WHERE tts.updated_at < ? OR tts.updated_at IS NULL
+             ORDER BY tts.updated_at ASC
+             LIMIT ?
+        ",
+        )
+        .bind(datetime.format(DATETIME_FORMAT).to_string())
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|_| database::Error::Error)
     }
 
     async fn update_torrent_title(&self, torrent_id: i64, title: &str) -> Result<(), database::Error> {

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -20,7 +20,7 @@ use crate::models::torrent_tag::{TagId, TorrentTag};
 use crate::models::tracker_key::TrackerKey;
 use crate::models::user::{User, UserAuthentication, UserCompact, UserId, UserProfile};
 use crate::services::torrent::{CanonicalInfoHashGroup, DbTorrentInfoHash};
-use crate::utils::clock;
+use crate::utils::clock::{self, datetime_now};
 use crate::utils::hex::from_bytes;
 
 pub struct Sqlite {
@@ -1047,11 +1047,12 @@ impl Database for Sqlite {
         seeders: i64,
         leechers: i64,
     ) -> Result<(), database::Error> {
-        query("REPLACE INTO torrust_torrent_tracker_stats (torrent_id, tracker_url, seeders, leechers) VALUES ($1, $2, $3, $4)")
+        query("REPLACE INTO torrust_torrent_tracker_stats (torrent_id, tracker_url, seeders, leechers, updated_at) VALUES ($1, $2, $3, $4, $5)")
             .bind(torrent_id)
             .bind(tracker_url)
             .bind(seeders)
             .bind(leechers)
+            .bind(datetime_now())
             .execute(&self.pool)
             .await
             .map(|_| ())

--- a/src/tracker/statistics_importer.rs
+++ b/src/tracker/statistics_importer.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use log::{error, info};
+use chrono::{DateTime, Utc};
+use log::{debug, error, info};
 use text_colorizer::Colorize;
 
 use super::service::{Service, TorrentInfo, TrackerAPIError};
@@ -36,13 +37,17 @@ impl StatisticsImporter {
     pub async fn import_all_torrents_statistics(&self) -> Result<(), database::Error> {
         let torrents = self.database.get_all_torrents_compact().await?;
 
+        if torrents.is_empty() {
+            return Ok(());
+        }
+
         info!(target: LOG_TARGET, "Importing {} torrents statistics from tracker {} ...", torrents.len().to_string().yellow(), self.tracker_url.yellow());
 
         // Start the timer before the loop
         let start_time = Instant::now();
 
         for torrent in torrents {
-            info!(target: LOG_TARGET, "Importing torrent #{} ...", torrent.torrent_id.to_string().yellow());
+            info!(target: LOG_TARGET, "Importing torrent #{} statistics ...", torrent.torrent_id.to_string().yellow());
 
             let ret = self.import_torrent_statistics(torrent.torrent_id, &torrent.info_hash).await;
 
@@ -53,6 +58,55 @@ impl StatisticsImporter {
                         torrent.torrent_id, torrent.info_hash, err
                     );
                     error!(target: "statistics_importer", "{}", message);
+                }
+            }
+        }
+
+        let elapsed_time = start_time.elapsed();
+
+        info!(target: LOG_TARGET, "Statistics import completed in {:.2?}", elapsed_time);
+
+        Ok(())
+    }
+
+    /// Import torrents statistics not updated recently..
+    ///
+    /// # Errors
+    ///
+    /// Will return an error if the database query failed.
+    pub async fn import_torrents_statistics_not_updated_since(
+        &self,
+        datetime: DateTime<Utc>,
+        limit: i64,
+    ) -> Result<(), database::Error> {
+        debug!(target: LOG_TARGET, "Importing torrents statistics not updated since {} limited to a maximum of {} torrents ...", datetime.to_string().yellow(), limit.to_string().yellow());
+
+        let torrents = self
+            .database
+            .get_torrents_with_stats_not_updated_since(datetime, limit)
+            .await?;
+
+        if torrents.is_empty() {
+            return Ok(());
+        }
+
+        info!(target: LOG_TARGET, "Importing {} torrents statistics from tracker {} ...", torrents.len().to_string().yellow(), self.tracker_url.yellow());
+
+        // Start the timer before the loop
+        let start_time = Instant::now();
+
+        for torrent in torrents {
+            info!(target: LOG_TARGET, "Importing torrent #{} statistics ...", torrent.torrent_id.to_string().yellow());
+
+            let ret = self.import_torrent_statistics(torrent.torrent_id, &torrent.info_hash).await;
+
+            if let Some(err) = ret.err() {
+                if err != TrackerAPIError::TorrentNotFound {
+                    let message = format!(
+                        "Error updating torrent tracker stats for torrent. Torrent: id {}; infohash {}. Error: {:?}",
+                        torrent.torrent_id, torrent.info_hash, err
+                    );
+                    error!(target: LOG_TARGET, "{}", message);
                 }
             }
         }

--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -1,3 +1,5 @@
+use chrono::Utc;
+
 /// Returns the current timestamp in seconds.
 ///
 /// # Panics
@@ -7,4 +9,12 @@
 #[must_use]
 pub fn now() -> u64 {
     u64::try_from(chrono::prelude::Utc::now().timestamp()).expect("timestamp should be positive")
+}
+
+/// Returns the current time in database format.
+///
+/// For example: `2024-03-12 15:56:24`.
+#[must_use]
+pub fn datetime_now() -> String {
+    Utc::now().format("%Y-%m-%d %H:%M:%S").to_string()
 }

--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -1,4 +1,6 @@
-use chrono::Utc;
+use chrono::{DateTime, Duration, Utc};
+
+pub const DATETIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S";
 
 /// Returns the current timestamp in seconds.
 ///
@@ -11,10 +13,16 @@ pub fn now() -> u64 {
     u64::try_from(chrono::prelude::Utc::now().timestamp()).expect("timestamp should be positive")
 }
 
+/// Returns the datetime some seconds ago.
+#[must_use]
+pub fn seconds_ago_utc(seconds: i64) -> DateTime<chrono::Utc> {
+    Utc::now() - Duration::seconds(seconds)
+}
+
 /// Returns the current time in database format.
 ///
 /// For example: `2024-03-12 15:56:24`.
 #[must_use]
 pub fn datetime_now() -> String {
-    Utc::now().format("%Y-%m-%d %H:%M:%S").to_string()
+    Utc::now().format(DATETIME_FORMAT).to_string()
 }


### PR DESCRIPTION
Currently, the Index imports statistics for all torrents every hour (1 hour is the default value in the configuration). We need to import stats for all torrents because we allow users to sort torrents by torrent stats (number of seeders and leechers). This PR improves a little bit the process.

- [x] Add a new field (`updated_at`) to the table `torrust_torrent_tracker_stats` with the datetime when the stats were imported from the tracker. This is for logging purposes but it also helps to import torrents in batches. Regarding logging, it could help to check that the cronjob is running correctly.
- [x] We get all torrents (`get_all_torrents_compact`) from the database. That could be big array of infohashes. We could obtain the 50 records that have not been updated for the longest time and run the importation every 100 milliseconds. We request the tracker API every 100 milliseconds getting 50 torrents. Those values can be adjusted in the future.
- [x] A [new filter was added to the tracker API to get statistics for a list of torrents with one request](https://github.com/torrust/torrust-tracker/pull/728). We can use it instead of getting one torrent at a time.

**Pros:**

- With millions of torrents we don't need to load all of them into memory.
- The new field `updated_at` helps to monitor the importation process.
- We get torrent stats for 50 torrents in one request instead of one request per torrent.

**Cons:**

- Every 100 milliseconds we run a query to check which torrent stats are pending to update.

