### PR TITLE
Fix new linting errors

### DIFF
--- a/src/console/commands/tracker_statistics_importer/app.rs
+++ b/src/console/commands/tracker_statistics_importer/app.rs
@@ -16,11 +16,11 @@
 //! Statistics are also imported:
 //!
 //! - Periodically by the importer job. The importer job is executed every hour
-//! by default. See [`TrackerStatisticsImporter`](crate::config::TrackerStatisticsImporter)
-//! for more details.
+//!   by default. See [`TrackerStatisticsImporter`](crate::config::TrackerStatisticsImporter)
+//!   for more details.
 //! - When a new torrent is added.
 //! - When the API returns data about a torrent statistics are collected from
-//! the tracker in real time.
+//!   the tracker in real time.
 use std::env;
 use std::sync::Arc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,8 @@
 //! ```
 //!
 //! > **NOTICE**: those are the commands for `Ubuntu`. If you are using a
-//! different OS, you will need to install the equivalent packages. Please
-//! refer to the documentation of your OS.
+//! > different OS, you will need to install the equivalent packages. Please
+//! > refer to the documentation of your OS.
 //!
 //! With the default configuration you will need to create the `storage` directory:
 //!
@@ -154,7 +154,7 @@
 //! > **WARNING**: The `.env` file is also used by docker-compose.
 //!
 //! > **NOTICE**: Refer to the [sqlx-cli](https://github.com/launchbadge/sqlx/tree/main/sqlx-cli)
-//! documentation for other commands to create new migrations or run them.
+//! > documentation for other commands to create new migrations or run them.
 //!
 //! > **NOTICE**: You can run the index with [tmux](https://github.com/tmux/tmux/wiki) with `tmux new -s torrust-index`.
 //!

--- a/src/upgrades/from_v1_0_0_to_v2_0_0/upgrader.rs
+++ b/src/upgrades/from_v1_0_0_to_v2_0_0/upgrader.rs
@@ -23,8 +23,8 @@
 //!
 //! - The database schema was changed.
 //! - The torrents are now stored entirely in the database. The torrent files
-//! are not stored in the filesystem anymore. This command reads the torrent
-//! files from the filesystem and store them in the database.
+//!   are not stored in the filesystem anymore. This command reads the torrent
+//!   files from the filesystem and store them in the database.
 //!
 //! We recommend to download your production database and the torrent files dir.
 //! And run the command in a local environment with the version `v2.0.0.`. Then,
@@ -36,13 +36,13 @@
 //! NOTES for `torrust_users` table transfer:
 //!
 //! - In v2, the table `torrust_user` contains a field `date_registered` non
-//! existing in v1. We changed that column to allow `NULL`. We also added the
-//! new column `date_imported` with the datetime when the upgrader was executed.
+//!   existing in v1. We changed that column to allow `NULL`. We also added the
+//!   new column `date_imported` with the datetime when the upgrader was executed.
 //!
 //! NOTES for `torrust_user_profiles` table transfer:
 //!
 //! - In v2, the table `torrust_user_profiles` contains two new fields: `bio`
-//! and `avatar`. Empty string is used as default value.
+//!   and `avatar`. Empty string is used as default value.
 //!
 //!
 //! If you want more information about this command you can read the [issue 56](https://github.com/torrust/torrust-index/issues/56).

--- a/src/utils/parse_torrent.rs
+++ b/src/utils/parse_torrent.rs
@@ -94,9 +94,9 @@ struct ParsedInfoDictFromMetainfoFile {
 /// This function will return an error if:
 ///
 /// - The torrent file is not a valid bencoded torrent file containing an `info`
-///  dictionary key.
+///   dictionary key.
 /// - The original torrent info-hash cannot be bencoded from the parsed `info`
-/// dictionary is not a valid bencoded dictionary.
+///   dictionary is not a valid bencoded dictionary.
 pub fn calculate_info_hash(bytes: &[u8]) -> Result<InfoHash, DecodeTorrentFileError> {
     // Extract the info dictionary
     let metainfo: ParsedInfoDictFromMetainfoFile =

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -7,8 +7,8 @@
 //! set the environment variable `TORRUST_INDEX_E2E_SHARED` to `true`.
 //!
 //! > **NOTICE**: The server must be running before running the tests. The
-//! server url is hardcoded to `http://localhost:3001` for now. We are planning
-//! to make it configurable in the future via a environment variable.
+//! > server url is hardcoded to `http://localhost:3001` for now. We are planning
+//! > to make it configurable in the future via a environment variable.
 //!
 //! ```text
 //! TORRUST_INDEX_E2E_SHARED=true cargo test
@@ -22,8 +22,8 @@
 //! ```
 //!
 //! > **NOTICE**: Some tests require the real tracker to be running, so they
-//! can only be run in shared mode until we implement a mock for the
-//! `torrust_index::tracker::TrackerService`.
+//! > can only be run in shared mode until we implement a mock for the
+//! > `torrust_index::tracker::TrackerService`.
 //!
 //! You may have errors like `Too many open files (os error 24)`. If so, you
 //! need to increase the limit of open files for the current user. You can do


### PR DESCRIPTION
The new Clippy version forces you to use indentation and also use the `>` marker in a multiline paragraph. For example:

**Not valid** because of the missing markers `>` and the indentation:

```
//! > **NOTICE**: The server must be running before running the tests. The
//! server url is hardcoded to `http://localhost:3001` for now. We are planning
//! to make it configurable in the future via a environment variable.
//!
```

**Valid**:

```
//! > **NOTICE**: The server must be running before running the tests. The
//! > server url is hardcoded to `http://localhost:3001` for now. We are planning
//! > to make it configurable in the future via a environment variable.
//!
```