### PR TITLE
Udpate tracker configuration

### DIFF
--- a/share/default/config/tracker.private.e2e.container.sqlite3.toml
+++ b/share/default/config/tracker.private.e2e.container.sqlite3.toml
@@ -1,5 +1,7 @@
+version = "2"
+
 [core]
-mode = "private"
+private = true
 
 [core.database]
 driver = "Sqlite3"

--- a/share/default/config/tracker.public.e2e.container.sqlite3.toml
+++ b/share/default/config/tracker.public.e2e.container.sqlite3.toml
@@ -1,5 +1,7 @@
+version = "2"
+
 [core]
-mode = "public"
+private = true
 
 [core.database]
 driver = "Sqlite3"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -136,12 +136,7 @@ impl From<figment::Error> for Error {
     }
 }
 
-// todo: use https://crates.io/crates/torrust-tracker-primitives for TrackerMode.
-
-/// The mode the tracker will run in.
-///
-/// Refer to [Torrust Tracker Configuration](https://docs.rs/torrust-tracker-configuration)
-/// to know how to configure the tracker to run in each mode.
+/// The mode the tracker is running in.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum TrackerMode {
     /// Will track every new info hash and serve every peer.

--- a/src/config/v1/tracker.rs
+++ b/src/config/v1/tracker.rs
@@ -13,9 +13,7 @@ pub struct Tracker {
     #[serde(default = "Tracker::default_api_url")]
     pub api_url: Url,
 
-    /// The mode of the tracker. For example: `Public`.
-    /// See `TrackerMode` in [`torrust-tracker-primitives`](https://docs.rs/torrust-tracker-primitives)
-    /// crate for more information.
+    /// The mode the tracker is running in.
     #[serde(default = "Tracker::default_mode")]
     pub mode: TrackerMode,
 


### PR DESCRIPTION
New breaking changes have been applied to the Tracker configuration.

- Renamed `log_level` to  `threshold`.
- Tracker mode split into `listed` and `private` flags.
- Added configuration `version`.

From:

```toml
[logging]
log_level = "info"

[core]
mode = "public"
tracker_usage_statistics = true
inactive_peer_cleanup_interval = 600

```

To:

```toml
version = "2"

[logging]
threshold = "info"

[core]
inactive_peer_cleanup_interval = 600
listed = false
private = false
tracker_usage_statistics = true

```