### PR TITLE
Configuration overhaul: rename `log_level` to `threshold`

### DIFF
--- a/share/default/config/index.container.mysql.toml
+++ b/share/default/config/index.container.mysql.toml
@@ -1,7 +1,12 @@
 version = "2"
 
 [logging]
-log_level = "info"
+#threshold = "off"
+#threshold = "error"
+#threshold = "warn"
+threshold = "info"
+#threshold = "debug"
+#threshold = "trace"
 
 [database]
 connect_url = "mysql://root:root_secret_password@mysql:3306/torrust_index"

--- a/share/default/config/index.container.sqlite3.toml
+++ b/share/default/config/index.container.sqlite3.toml
@@ -1,7 +1,12 @@
 version = "2"
 
 [logging]
-log_level = "info"
+#threshold = "off"
+#threshold = "error"
+#threshold = "warn"
+threshold = "info"
+#threshold = "debug"
+#threshold = "trace"
 
 [database]
 connect_url = "sqlite:///var/lib/torrust/index/database/sqlite3.db?mode=rwc"

--- a/share/default/config/index.development.sqlite3.toml
+++ b/share/default/config/index.development.sqlite3.toml
@@ -1,7 +1,12 @@
 version = "2"
 
 [logging]
-log_level = "info"
+#threshold = "off"
+#threshold = "error"
+#threshold = "warn"
+threshold = "info"
+#threshold = "debug"
+#threshold = "trace"
 
 # Uncomment if you want to enable TSL for development
 #[net.tsl]

--- a/share/default/config/index.private.e2e.container.sqlite3.toml
+++ b/share/default/config/index.private.e2e.container.sqlite3.toml
@@ -1,7 +1,12 @@
 version = "2"
 
 [logging]
-log_level = "info"
+#threshold = "off"
+#threshold = "error"
+#threshold = "warn"
+threshold = "info"
+#threshold = "debug"
+#threshold = "trace"
 
 [tracker]
 api_url = "http://tracker:1212"

--- a/share/default/config/index.public.e2e.container.mysql.toml
+++ b/share/default/config/index.public.e2e.container.mysql.toml
@@ -1,7 +1,12 @@
 version = "2"
 
 [logging]
-log_level = "info"
+#threshold = "off"
+#threshold = "error"
+#threshold = "warn"
+threshold = "info"
+#threshold = "debug"
+#threshold = "trace"
 
 [tracker]
 api_url = "http://tracker:1212"

--- a/share/default/config/index.public.e2e.container.sqlite3.toml
+++ b/share/default/config/index.public.e2e.container.sqlite3.toml
@@ -1,7 +1,12 @@
 version = "2"
 
 [logging]
-log_level = "info"
+#threshold = "off"
+#threshold = "error"
+#threshold = "warn"
+threshold = "info"
+#threshold = "debug"
+#threshold = "trace"
 
 [tracker]
 api_url = "http://tracker:1212"

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,9 +39,9 @@ pub struct Running {
 /// It panics if there is an error connecting to the database.
 #[allow(clippy::too_many_lines)]
 pub async fn run(configuration: Configuration, api_version: &Version) -> Running {
-    let log_level = configuration.settings.read().await.logging.log_level.clone();
+    let threshold = configuration.settings.read().await.logging.threshold.clone();
 
-    logging::setup(&log_level);
+    logging::setup(&threshold);
 
     log_configuration(&configuration).await;
 

--- a/src/bootstrap/logging.rs
+++ b/src/bootstrap/logging.rs
@@ -11,19 +11,19 @@ use std::sync::Once;
 use tracing::info;
 use tracing::level_filters::LevelFilter;
 
-use crate::config::LogLevel;
+use crate::config::Threshold;
 
 static INIT: Once = Once::new();
 
-pub fn setup(log_level: &LogLevel) {
-    let tracing_level: LevelFilter = log_level.clone().into();
+pub fn setup(threshold: &Threshold) {
+    let tracing_level_filter: LevelFilter = threshold.clone().into();
 
-    if tracing_level == LevelFilter::OFF {
+    if tracing_level_filter == LevelFilter::OFF {
         return;
     }
 
     INIT.call_once(|| {
-        tracing_stdout_init(tracing_level, &TraceStyle::Default);
+        tracing_stdout_init(tracing_level_filter, &TraceStyle::Default);
     });
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -44,7 +44,7 @@ pub type Tracker = v2::tracker::Tracker;
 pub type ApiToken = v2::tracker::ApiToken;
 
 pub type Logging = v2::logging::Logging;
-pub type LogLevel = v2::logging::LogLevel;
+pub type Threshold = v2::logging::Threshold;
 
 pub type Website = v2::website::Website;
 
@@ -408,7 +408,7 @@ mod tests {
         let config = r#"version = "2"
 
                                 [logging]
-                                log_level = "info"
+                                threshold = "info"
 
                                 [website]
                                 name = "Torrust"

--- a/src/config/v2/logging.rs
+++ b/src/config/v2/logging.rs
@@ -7,70 +7,70 @@ use tracing::level_filters::LevelFilter;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Logging {
     /// Logging level. Possible values are: `Off`, `Error`, `Warn`, `Info`, `Debug`, `Trace`.
-    #[serde(default = "Logging::default_log_level")]
-    pub log_level: LogLevel,
+    #[serde(default = "Logging::default_threshold")]
+    pub threshold: Threshold,
 }
 
 impl Default for Logging {
     fn default() -> Self {
         Self {
-            log_level: Logging::default_log_level(),
+            threshold: Logging::default_threshold(),
         }
     }
 }
 
 impl Logging {
-    fn default_log_level() -> LogLevel {
-        LogLevel::Info
+    fn default_threshold() -> Threshold {
+        Threshold::Info
     }
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Clone)]
 #[serde(rename_all = "lowercase")]
-pub enum LogLevel {
-    /// A level lower than all log levels.
+pub enum Threshold {
+    /// A level lower than all log security levels.
     Off,
-    /// Corresponds to the `Error` log level.
+    /// Corresponds to the `Error` log security level.
     Error,
-    /// Corresponds to the `Warn` log level.
+    /// Corresponds to the `Warn` log security level.
     Warn,
-    /// Corresponds to the `Info` log level.
+    /// Corresponds to the `Info` log security level.
     Info,
-    /// Corresponds to the `Debug` log level.
+    /// Corresponds to the `Debug` log security level.
     Debug,
-    /// Corresponds to the `Trace` log level.
+    /// Corresponds to the `Trace` log security level.
     Trace,
 }
 
-impl Default for LogLevel {
+impl Default for Threshold {
     fn default() -> Self {
         Self::Info
     }
 }
 
-impl fmt::Display for LogLevel {
+impl fmt::Display for Threshold {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let display_str = match self {
-            LogLevel::Off => "off",
-            LogLevel::Error => "error",
-            LogLevel::Warn => "warn",
-            LogLevel::Info => "info",
-            LogLevel::Debug => "debug",
-            LogLevel::Trace => "trace",
+            Threshold::Off => "off",
+            Threshold::Error => "error",
+            Threshold::Warn => "warn",
+            Threshold::Info => "info",
+            Threshold::Debug => "debug",
+            Threshold::Trace => "trace",
         };
         write!(f, "{display_str}")
     }
 }
 
-impl From<LogLevel> for LevelFilter {
-    fn from(log_level: LogLevel) -> Self {
-        match log_level {
-            LogLevel::Off => LevelFilter::OFF,
-            LogLevel::Error => LevelFilter::ERROR,
-            LogLevel::Warn => LevelFilter::WARN,
-            LogLevel::Info => LevelFilter::INFO,
-            LogLevel::Debug => LevelFilter::DEBUG,
-            LogLevel::Trace => LevelFilter::TRACE,
+impl From<Threshold> for LevelFilter {
+    fn from(threshold: Threshold) -> Self {
+        match threshold {
+            Threshold::Off => LevelFilter::OFF,
+            Threshold::Error => LevelFilter::ERROR,
+            Threshold::Warn => LevelFilter::WARN,
+            Threshold::Info => LevelFilter::INFO,
+            Threshold::Debug => LevelFilter::DEBUG,
+            Threshold::Trace => LevelFilter::TRACE,
         }
     }
 }

--- a/src/console/commands/tracker_statistics_importer/app.rs
+++ b/src/console/commands/tracker_statistics_importer/app.rs
@@ -90,9 +90,9 @@ pub async fn import() {
 
     let configuration = initialize_configuration();
 
-    let log_level = configuration.settings.read().await.logging.log_level.clone();
+    let threshold = configuration.settings.read().await.logging.threshold.clone();
 
-    logging::setup(&log_level);
+    logging::setup(&threshold);
 
     let cfg = Arc::new(configuration);
 

--- a/tests/common/contexts/settings/mod.rs
+++ b/tests/common/contexts/settings/mod.rs
@@ -27,7 +27,7 @@ pub struct Settings {
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Logging {
-    pub log_level: String,
+    pub threshold: String,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -130,7 +130,7 @@ impl From<DomainSettings> for Settings {
 impl From<DomainLogging> for Logging {
     fn from(logging: DomainLogging) -> Self {
         Self {
-            log_level: logging.log_level.to_string(),
+            threshold: logging.threshold.to_string(),
         }
     }
 }

--- a/tests/environments/isolated.rs
+++ b/tests/environments/isolated.rs
@@ -2,7 +2,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use tempfile::TempDir;
 use torrust_index::config;
-use torrust_index::config::{LogLevel, FREE_PORT};
+use torrust_index::config::{Threshold, FREE_PORT};
 use torrust_index::web::api::Version;
 use url::Url;
 
@@ -75,7 +75,7 @@ impl Default for TestEnv {
 fn ephemeral(temp_dir: &TempDir) -> config::Settings {
     let mut configuration = config::Settings::default();
 
-    configuration.logging.log_level = LogLevel::Off; // Change to `debug` for tests debugging
+    configuration.logging.threshold = Threshold::Off; // Change to `debug` for tests debugging
 
     // Ephemeral API port
     configuration.net.bind_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), FREE_PORT);


### PR DESCRIPTION
Rename `log_level` to `threshold`:

```toml
[logging]
log_level = "info"
```

```toml
[logging]
threshold = "info"
```