### PR TITLE
Configuration overhaul: split `TrackerMode`into two flags `private` and `listed`

### DIFF
--- a/share/default/config/index.private.e2e.container.sqlite3.toml
+++ b/share/default/config/index.private.e2e.container.sqlite3.toml
@@ -10,7 +10,8 @@ threshold = "info"
 
 [tracker]
 api_url = "http://tracker:1212"
-mode = "private"
+listed = false
+private = true
 url = "http://tracker:7070"
 
 [database]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //! ```toml
 //! [tracker]
 //! url = "udp://localhost:6969"
-//! mode = "public"
+//!
 //! api_url = "http://localhost:1212/"
 //! token = "MyAccessToken"
 //! token_valid_seconds = 7257600
@@ -170,11 +170,12 @@
 //! name = "Torrust"
 //!
 //! [tracker]
-//! url = "udp://localhost:6969"
-//! mode = "public"
 //! api_url = "http://localhost:1212/"
+//! listed = false
+//! private = false
 //! token = "MyAccessToken"
 //! token_valid_seconds = 7257600
+//! url = "udp://localhost:6969"
 //!
 //! [net]
 //! bind_address = "0.0.0.0:3001"

--- a/src/web/api/client/v1/contexts/settings/mod.rs
+++ b/src/web/api/client/v1/contexts/settings/mod.rs
@@ -34,7 +34,8 @@ pub struct Website {
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Tracker {
     pub url: Url,
-    pub mode: String,
+    pub listed: bool,
+    pub private: bool,
     pub api_url: Url,
     pub token: ApiToken,
     pub token_valid_seconds: u64,
@@ -132,7 +133,8 @@ impl From<DomainTracker> for Tracker {
     fn from(tracker: DomainTracker) -> Self {
         Self {
             url: tracker.url,
-            mode: format!("{:?}", tracker.mode),
+            listed: tracker.listed,
+            private: tracker.private,
             api_url: tracker.api_url,
             token: tracker.token,
             token_valid_seconds: tracker.token_valid_seconds,

--- a/tests/common/contexts/settings/mod.rs
+++ b/tests/common/contexts/settings/mod.rs
@@ -38,7 +38,8 @@ pub struct Website {
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Tracker {
     pub url: Url,
-    pub mode: String,
+    pub listed: bool,
+    pub private: bool,
     pub api_url: Url,
     pub token: ApiToken,
     pub token_valid_seconds: u64,
@@ -145,7 +146,8 @@ impl From<DomainTracker> for Tracker {
     fn from(tracker: DomainTracker) -> Self {
         Self {
             url: tracker.url,
-            mode: tracker.mode.to_string(),
+            listed: tracker.listed,
+            private: tracker.private,
             api_url: tracker.api_url,
             token: tracker.token,
             token_valid_seconds: tracker.token_valid_seconds,

--- a/tests/common/contexts/settings/responses.rs
+++ b/tests/common/contexts/settings/responses.rs
@@ -17,7 +17,8 @@ pub struct PublicSettingsResponse {
 pub struct Public {
     pub website_name: String,
     pub tracker_url: Url,
-    pub tracker_mode: String,
+    pub tracker_listed: bool,
+    pub tracker_private: bool,
     pub email_on_signup: String,
 }
 

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -1,7 +1,6 @@
 use std::env;
-use std::str::FromStr;
 
-use torrust_index::config::{ApiToken, TrackerMode};
+use torrust_index::config::ApiToken;
 use torrust_index::web::api::Version;
 use url::Url;
 
@@ -88,9 +87,7 @@ impl TestEnv {
         };
 
         match self.server_settings() {
-            Some(settings) => {
-                TrackerMode::from_str(&settings.tracker.mode).expect("it should be a valid tracker mode") == TrackerMode::Private
-            }
+            Some(settings) => settings.tracker.private,
             None => false,
         }
     }

--- a/tests/e2e/web/api/v1/contexts/settings/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/settings/contract.rs
@@ -25,7 +25,8 @@ async fn it_should_allow_guests_to_get_the_public_settings() {
         Public {
             website_name: env.server_settings().unwrap().website.name,
             tracker_url: env.server_settings().unwrap().tracker.url,
-            tracker_mode: env.server_settings().unwrap().tracker.mode,
+            tracker_listed: env.server_settings().unwrap().tracker.listed,
+            tracker_private: env.server_settings().unwrap().tracker.private,
             email_on_signup: env.server_settings().unwrap().auth.email_on_signup,
         }
     );


### PR DESCRIPTION
Update the tracker configuration section to follow [changes in the tracker configuration](https://github.com/torrust/torrust-tracker/issues/932).

```toml
[tracker]
mode = "public"
```

```toml
[tracker]
private = false
listed = false
```

**NOTICE**: This introduces a breaking change in the Tracker API. The Index GUI must be updated. It will open a new issue in the Index GUI repo and update it today.