### PR TITLE
Configuration overhaul: make mail-related configuration clearer

### DIFF
--- a/share/default/config/index.container.mysql.toml
+++ b/share/default/config/index.container.mysql.toml
@@ -15,3 +15,5 @@ connect_url = "mysql://root:root_secret_password@mysql:3306/torrust_index"
 port = 1025
 server = "mailcatcher"
 
+[registration]
+[registration.email]

--- a/share/default/config/index.container.sqlite3.toml
+++ b/share/default/config/index.container.sqlite3.toml
@@ -14,3 +14,6 @@ connect_url = "sqlite:///var/lib/torrust/index/database/sqlite3.db?mode=rwc"
 [mail.smtp]
 port = 1025
 server = "mailcatcher"
+
+[registration]
+[registration.email]

--- a/share/default/config/index.development.sqlite3.toml
+++ b/share/default/config/index.development.sqlite3.toml
@@ -12,3 +12,6 @@ threshold = "info"
 #[net.tsl]
 #ssl_cert_path = "./storage/index/lib/tls/localhost.crt"
 #ssl_key_path = "./storage/index/lib/tls/localhost.key"
+
+[registration]
+[registration.email]

--- a/share/default/config/index.private.e2e.container.sqlite3.toml
+++ b/share/default/config/index.private.e2e.container.sqlite3.toml
@@ -20,3 +20,6 @@ connect_url = "sqlite:///var/lib/torrust/index/database/e2e_testing_sqlite3.db?m
 [mail.smtp]
 port = 1025
 server = "mailcatcher"
+
+[registration]
+[registration.email]

--- a/share/default/config/index.public.e2e.container.mysql.toml
+++ b/share/default/config/index.public.e2e.container.mysql.toml
@@ -18,3 +18,6 @@ connect_url = "mysql://root:root_secret_password@mysql:3306/torrust_index_e2e_te
 [mail.smtp]
 port = 1025
 server = "mailcatcher"
+
+[registration]
+[registration.email]

--- a/share/default/config/index.public.e2e.container.sqlite3.toml
+++ b/share/default/config/index.public.e2e.container.sqlite3.toml
@@ -18,3 +18,6 @@ connect_url = "sqlite:///var/lib/torrust/index/database/e2e_testing_sqlite3.db?m
 [mail.smtp]
 port = 1025
 server = "mailcatcher"
+
+[registration]
+[registration.email]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -433,7 +433,6 @@ mod tests {
                                 connect_url = "sqlite://data.db?mode=rwc"
 
                                 [mail]
-                                email_verification_enabled = false
                                 from = "example@email.com"
                                 reply_to = "noreply@email.com"
 

--- a/src/config/v2/auth.rs
+++ b/src/config/v2/auth.rs
@@ -1,15 +1,10 @@
 use std::fmt;
-use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
 /// Authentication options.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Auth {
-    /// Whether or not to require an email on signup.
-    #[serde(default = "Auth::default_email_on_signup")]
-    pub email_on_signup: EmailOnSignup,
-
     /// The secret key used to sign JWT tokens.
     #[serde(default = "Auth::default_secret_key")]
     pub secret_key: SecretKey,
@@ -22,7 +17,6 @@ pub struct Auth {
 impl Default for Auth {
     fn default() -> Self {
         Self {
-            email_on_signup: EmailOnSignup::default(),
             password_constraints: Self::default_password_constraints(),
             secret_key: Self::default_secret_key(),
         }
@@ -34,60 +28,12 @@ impl Auth {
         self.secret_key = SecretKey::new(secret_key);
     }
 
-    fn default_email_on_signup() -> EmailOnSignup {
-        EmailOnSignup::default()
-    }
-
     fn default_secret_key() -> SecretKey {
         SecretKey::new("MaxVerstappenWC2021")
     }
 
     fn default_password_constraints() -> PasswordConstraints {
         PasswordConstraints::default()
-    }
-}
-
-/// Whether the email is required on signup or not.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum EmailOnSignup {
-    /// The email is required on signup.
-    Required,
-    /// The email is optional on signup.
-    Optional,
-    /// The email is not allowed on signup. It will only be ignored if provided.
-    Ignored,
-}
-
-impl Default for EmailOnSignup {
-    fn default() -> Self {
-        Self::Optional
-    }
-}
-
-impl fmt::Display for EmailOnSignup {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let display_str = match self {
-            EmailOnSignup::Required => "required",
-            EmailOnSignup::Optional => "optional",
-            EmailOnSignup::Ignored => "ignored",
-        };
-        write!(f, "{display_str}")
-    }
-}
-
-impl FromStr for EmailOnSignup {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "required" => Ok(EmailOnSignup::Required),
-            "optional" => Ok(EmailOnSignup::Optional),
-            "none" => Ok(EmailOnSignup::Ignored),
-            _ => Err(format!(
-                "Unknown config 'email_on_signup' option (required, optional, ignored): {s}"
-            )),
-        }
     }
 }
 

--- a/src/config/v2/mail.rs
+++ b/src/config/v2/mail.rs
@@ -4,10 +4,6 @@ use serde::{Deserialize, Serialize};
 /// SMTP configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Mail {
-    /// Whether or not to enable email verification on signup.
-    #[serde(default = "Mail::default_email_verification_enabled")]
-    pub email_verification_enabled: bool,
-
     /// The email address to send emails from.
     #[serde(default = "Mail::default_from")]
     pub from: Mailbox,
@@ -24,7 +20,6 @@ pub struct Mail {
 impl Default for Mail {
     fn default() -> Self {
         Self {
-            email_verification_enabled: Self::default_email_verification_enabled(),
             from: Self::default_from(),
             reply_to: Self::default_reply_to(),
             smtp: Self::default_smtp(),
@@ -33,10 +28,6 @@ impl Default for Mail {
 }
 
 impl Mail {
-    fn default_email_verification_enabled() -> bool {
-        false
-    }
-
     fn default_from() -> Mailbox {
         "example@email.com".parse().expect("valid mailbox")
     }

--- a/src/config/v2/mod.rs
+++ b/src/config/v2/mod.rs
@@ -5,11 +5,13 @@ pub mod image_cache;
 pub mod logging;
 pub mod mail;
 pub mod net;
+pub mod registration;
 pub mod tracker;
 pub mod tracker_statistics_importer;
 pub mod website;
 
 use logging::Logging;
+use registration::Registration;
 use serde::{Deserialize, Serialize};
 
 use self::api::Api;
@@ -25,51 +27,75 @@ use super::validator::{ValidationError, Validator};
 use super::Metadata;
 
 /// The whole configuration for the index.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Settings {
     /// Configuration metadata.
+    #[serde(default = "Settings::default_metadata")]
     #[serde(flatten)]
     pub metadata: Metadata,
 
     /// The logging configuration.
-    #[serde(default)]
+    #[serde(default = "Settings::default_logging")]
     pub logging: Logging,
 
     /// The website customizable values.
-    #[serde(default)]
+    #[serde(default = "Settings::default_website")]
     pub website: Website,
 
     /// The tracker configuration.
-    #[serde(default)]
+    #[serde(default = "Settings::default_tracker")]
     pub tracker: Tracker,
 
     /// The network configuration.
-    #[serde(default)]
+    #[serde(default = "Settings::default_network")]
     pub net: Network,
 
     /// The authentication configuration.
-    #[serde(default)]
+    #[serde(default = "Settings::default_auth")]
     pub auth: Auth,
 
     /// The database configuration.
-    #[serde(default)]
+    #[serde(default = "Settings::default_database")]
     pub database: Database,
 
     /// The SMTP configuration.
-    #[serde(default)]
+    #[serde(default = "Settings::default_mail")]
     pub mail: Mail,
 
     /// The image proxy cache configuration.
-    #[serde(default)]
+    #[serde(default = "Settings::default_image_cache")]
     pub image_cache: ImageCache,
 
     /// The API configuration.
-    #[serde(default)]
+    #[serde(default = "Settings::default_api")]
     pub api: Api,
 
+    /// The registration configuration.
+    #[serde(default = "Settings::default_registration")]
+    pub registration: Option<Registration>,
+
     /// The tracker statistics importer job configuration.
-    #[serde(default)]
+    #[serde(default = "Settings::default_tracker_statistics_importer")]
     pub tracker_statistics_importer: TrackerStatisticsImporter,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            metadata: Self::default_metadata(),
+            logging: Self::default_logging(),
+            website: Self::default_website(),
+            tracker: Self::default_tracker(),
+            net: Self::default_network(),
+            auth: Self::default_auth(),
+            database: Self::default_database(),
+            mail: Self::default_mail(),
+            image_cache: Self::default_image_cache(),
+            api: Self::default_api(),
+            registration: Self::default_registration(),
+            tracker_statistics_importer: Self::default_tracker_statistics_importer(),
+        }
+    }
 }
 
 impl Settings {
@@ -100,6 +126,54 @@ impl Settings {
     #[must_use]
     pub fn to_json(&self) -> String {
         serde_json::to_string_pretty(self).expect("Could not encode JSON value")
+    }
+
+    fn default_metadata() -> Metadata {
+        Metadata::default()
+    }
+
+    fn default_logging() -> Logging {
+        Logging::default()
+    }
+
+    fn default_website() -> Website {
+        Website::default()
+    }
+
+    fn default_tracker() -> Tracker {
+        Tracker::default()
+    }
+
+    fn default_network() -> Network {
+        Network::default()
+    }
+
+    fn default_auth() -> Auth {
+        Auth::default()
+    }
+
+    fn default_database() -> Database {
+        Database::default()
+    }
+
+    fn default_mail() -> Mail {
+        Mail::default()
+    }
+
+    fn default_image_cache() -> ImageCache {
+        ImageCache::default()
+    }
+
+    fn default_api() -> Api {
+        Api::default()
+    }
+
+    fn default_registration() -> Option<Registration> {
+        None
+    }
+
+    fn default_tracker_statistics_importer() -> TrackerStatisticsImporter {
+        TrackerStatisticsImporter::default()
     }
 }
 

--- a/src/config/v2/registration.rs
+++ b/src/config/v2/registration.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+
+/// SMTP configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Registration {
+    /// Whether or not to enable email verification on signup.
+    #[serde(default = "Registration::default_email")]
+    pub email: Option<Email>,
+}
+
+impl Default for Registration {
+    fn default() -> Self {
+        Self {
+            email: Self::default_email(),
+        }
+    }
+}
+
+impl Registration {
+    fn default_email() -> Option<Email> {
+        None
+    }
+}
+
+/// SMTP configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Email {
+    /// Whether or not email is required on signup.
+    #[serde(default = "Email::default_required")]
+    pub required: bool,
+
+    /// Whether or not email is verified.
+    #[serde(default = "Email::default_verified")]
+    pub verified: bool,
+}
+
+impl Default for Email {
+    fn default() -> Self {
+        Self {
+            required: Self::default_required(),
+            verified: Self::default_verified(),
+        }
+    }
+}
+
+impl Email {
+    fn default_required() -> bool {
+        false
+    }
+
+    fn default_verified() -> bool {
+        false
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,6 @@
 //! bind_address = "0.0.0.0:3001"
 //!
 //! [auth]
-//! email_on_signup = "optional"
 //! secret_key = "MaxVerstappenWC2021"
 //!
 //! [auth.password_constraints]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,6 @@
 //! connect_url = "sqlite://data.db?mode=rwc"
 //!
 //! [mail]
-//! email_verification_enabled = false
 //! from = "example@email.com"
 //! reply_to = "noreply@email.com"
 //!

--- a/src/services/authentication.rs
+++ b/src/services/authentication.rs
@@ -70,8 +70,12 @@ impl Service {
         let settings = self.configuration.settings.read().await;
 
         // Fail login if email verification is required and this email is not verified
-        if settings.mail.email_verification_enabled && !user_profile.email_verified {
-            return Err(ServiceError::EmailNotVerified);
+        if let Some(registration) = &settings.registration {
+            if let Some(email) = &registration.email {
+                if email.verified && !user_profile.email_verified {
+                    return Err(ServiceError::EmailNotVerified);
+                }
+            }
         }
 
         // Drop read lock on settings

--- a/src/services/settings.rs
+++ b/src/services/settings.rs
@@ -1,8 +1,13 @@
 //! Settings service.
+use std::fmt;
+use std::str::FromStr;
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
+use url::Url;
+
 use super::authorization::{self, ACTION};
-use crate::config::{Configuration, ConfigurationPublic, Settings};
+use crate::config::{Configuration, Settings};
 use crate::errors::ServiceError;
 use crate::models::user::UserId;
 
@@ -58,7 +63,8 @@ impl Service {
     ///
     /// It returns an error if the user does not have the required permissions.
     pub async fn get_public(&self) -> ConfigurationPublic {
-        self.configuration.get_public().await
+        let settings_lock = self.configuration.get_all().await;
+        extract_public_settings(&settings_lock)
     }
 
     /// It gets the site name from the settings.
@@ -68,5 +74,121 @@ impl Service {
     /// It returns an error if the user does not have the required permissions.
     pub async fn get_site_name(&self) -> String {
         self.configuration.get_site_name().await
+    }
+}
+
+fn extract_public_settings(settings: &Settings) -> ConfigurationPublic {
+    let email_on_signup = match &settings.registration {
+        Some(registration) => match &registration.email {
+            Some(email) => {
+                if email.required {
+                    EmailOnSignup::Required
+                } else {
+                    EmailOnSignup::Optional
+                }
+            }
+            None => EmailOnSignup::NotIncluded,
+        },
+        None => EmailOnSignup::NotIncluded,
+    };
+
+    ConfigurationPublic {
+        website_name: settings.website.name.clone(),
+        tracker_url: settings.tracker.url.clone(),
+        tracker_listed: settings.tracker.listed,
+        tracker_private: settings.tracker.private,
+        email_on_signup,
+    }
+}
+
+/// The public index configuration.
+/// There is an endpoint to get this configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConfigurationPublic {
+    website_name: String,
+    tracker_url: Url,
+    tracker_listed: bool,
+    tracker_private: bool,
+    email_on_signup: EmailOnSignup,
+}
+
+/// Whether the email is required on signup or not.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum EmailOnSignup {
+    /// The email is required on signup.
+    Required,
+    /// The email is optional on signup.
+    Optional,
+    /// The email is not allowed on signup. It will only be ignored if provided.
+    NotIncluded,
+}
+
+impl Default for EmailOnSignup {
+    fn default() -> Self {
+        Self::Optional
+    }
+}
+
+impl fmt::Display for EmailOnSignup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let display_str = match self {
+            EmailOnSignup::Required => "required",
+            EmailOnSignup::Optional => "optional",
+            EmailOnSignup::NotIncluded => "ignored",
+        };
+        write!(f, "{display_str}")
+    }
+}
+
+impl FromStr for EmailOnSignup {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "required" => Ok(EmailOnSignup::Required),
+            "optional" => Ok(EmailOnSignup::Optional),
+            "none" => Ok(EmailOnSignup::NotIncluded),
+            _ => Err(format!(
+                "Unknown config 'email_on_signup' option (required, optional, none): {s}"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::Configuration;
+    use crate::services::settings::{extract_public_settings, ConfigurationPublic, EmailOnSignup};
+
+    #[tokio::test]
+    async fn configuration_should_return_only_public_settings() {
+        let configuration = Configuration::default();
+        let all_settings = configuration.get_all().await;
+
+        let email_on_signup = match &all_settings.registration {
+            Some(registration) => match &registration.email {
+                Some(email) => {
+                    if email.required {
+                        EmailOnSignup::Required
+                    } else {
+                        EmailOnSignup::Optional
+                    }
+                }
+                None => EmailOnSignup::NotIncluded,
+            },
+            None => EmailOnSignup::NotIncluded,
+        };
+
+        assert_eq!(
+            extract_public_settings(&all_settings),
+            ConfigurationPublic {
+                website_name: all_settings.website.name,
+                tracker_url: all_settings.tracker.url,
+                tracker_listed: all_settings.tracker.listed,
+                tracker_private: all_settings.tracker.private,
+                email_on_signup,
+            }
+        );
     }
 }

--- a/src/services/user.rs
+++ b/src/services/user.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info};
 
 use super::authentication::DbUserAuthenticationRepository;
 use super::authorization::{self, ACTION};
-use crate::config::{Configuration, EmailOnSignup, PasswordConstraints};
+use crate::config::{Configuration, PasswordConstraints};
 use crate::databases::database::{Database, Error};
 use crate::errors::ServiceError;
 use crate::mailer;
@@ -74,71 +74,75 @@ impl RegistrationService {
     pub async fn register_user(&self, registration_form: &RegistrationForm, api_base_url: &str) -> Result<UserId, ServiceError> {
         info!("registering user: {}", registration_form.username);
 
-        let Ok(username) = registration_form.username.parse::<Username>() else {
-            return Err(ServiceError::UsernameInvalid);
-        };
-
         let settings = self.configuration.settings.read().await;
 
-        let opt_email = match settings.auth.email_on_signup {
-            EmailOnSignup::Required => {
-                if registration_form.email.is_none() {
-                    return Err(ServiceError::EmailMissing);
+        match &settings.registration {
+            Some(registration) => {
+                let Ok(username) = registration_form.username.parse::<Username>() else {
+                    return Err(ServiceError::UsernameInvalid);
+                };
+
+                let opt_email = match &registration.email {
+                    Some(email) => {
+                        if email.required && registration_form.email.is_none() {
+                            return Err(ServiceError::EmailMissing);
+                        }
+                        registration_form.email.clone()
+                    }
+                    None => None,
+                };
+
+                if let Some(email) = &registration_form.email {
+                    if !validate_email_address(email) {
+                        return Err(ServiceError::EmailInvalid);
+                    }
                 }
-                registration_form.email.clone()
-            }
-            EmailOnSignup::Ignored => None,
-            EmailOnSignup::Optional => registration_form.email.clone(),
-        };
 
-        if let Some(email) = &registration_form.email {
-            if !validate_email_address(email) {
-                return Err(ServiceError::EmailInvalid);
-            }
-        }
+                let password_constraints = PasswordConstraints {
+                    min_password_length: settings.auth.password_constraints.min_password_length,
+                    max_password_length: settings.auth.password_constraints.max_password_length,
+                };
 
-        let password_constraints = PasswordConstraints {
-            min_password_length: settings.auth.password_constraints.min_password_length,
-            max_password_length: settings.auth.password_constraints.max_password_length,
-        };
+                validate_password_constraints(
+                    &registration_form.password,
+                    &registration_form.confirm_password,
+                    &password_constraints,
+                )?;
 
-        validate_password_constraints(
-            &registration_form.password,
-            &registration_form.confirm_password,
-            &password_constraints,
-        )?;
+                let password_hash = hash_password(&registration_form.password)?;
 
-        let password_hash = hash_password(&registration_form.password)?;
+                let user_id = self
+                    .user_repository
+                    .add(
+                        &username.to_string(),
+                        &opt_email.clone().unwrap_or(no_email()),
+                        &password_hash,
+                    )
+                    .await?;
 
-        let user_id = self
-            .user_repository
-            .add(
-                &username.to_string(),
-                &opt_email.clone().unwrap_or(no_email()),
-                &password_hash,
-            )
-            .await?;
-
-        // If this is the first created account, give administrator rights
-        if user_id == 1 {
-            drop(self.user_repository.grant_admin_role(&user_id).await);
-        }
-
-        if settings.mail.email_verification_enabled {
-            if let Some(email) = opt_email {
-                let mail_res = self
-                    .mailer
-                    .send_verification_mail(&email, &registration_form.username, user_id, api_base_url)
-                    .await;
-
-                if mail_res.is_err() {
-                    drop(self.user_repository.delete(&user_id).await);
-                    return Err(ServiceError::FailedToSendVerificationEmail);
+                // If this is the first created account, give administrator rights
+                if user_id == 1 {
+                    drop(self.user_repository.grant_admin_role(&user_id).await);
                 }
-            }
-        }
 
-        Ok(user_id)
+                if settings.mail.email_verification_enabled {
+                    if let Some(email) = opt_email {
+                        let mail_res = self
+                            .mailer
+                            .send_verification_mail(&email, &registration_form.username, user_id, api_base_url)
+                            .await;
+
+                        if mail_res.is_err() {
+                            drop(self.user_repository.delete(&user_id).await);
+                            return Err(ServiceError::FailedToSendVerificationEmail);
+                        }
+                    }
+                }
+
+                Ok(user_id)
+            }
+            None => Err(ServiceError::ClosedForRegistration),
+        }
     }
 
     /// It verifies the email address of a user via the token sent to the

--- a/src/services/user.rs
+++ b/src/services/user.rs
@@ -87,12 +87,21 @@ impl RegistrationService {
                         if email.required && registration_form.email.is_none() {
                             return Err(ServiceError::EmailMissing);
                         }
-                        registration_form.email.clone()
+                        match &registration_form.email {
+                            Some(email) => {
+                                if email.trim() == String::new() {
+                                    None
+                                } else {
+                                    Some(email.clone())
+                                }
+                            }
+                            None => None,
+                        }
                     }
                     None => None,
                 };
 
-                if let Some(email) = &registration_form.email {
+                if let Some(email) = &opt_email {
                     if !validate_email_address(email) {
                         return Err(ServiceError::EmailInvalid);
                     }

--- a/src/web/api/client/v1/contexts/settings/mod.rs
+++ b/src/web/api/client/v1/contexts/settings/mod.rs
@@ -66,7 +66,6 @@ pub struct Database {
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Mail {
-    pub email_verification_enabled: bool,
     pub from: String,
     pub reply_to: String,
     pub smtp: Smtp,
@@ -179,7 +178,6 @@ impl From<DomainDatabase> for Database {
 impl From<DomainMail> for Mail {
     fn from(mail: DomainMail) -> Self {
         Self {
-            email_verification_enabled: mail.email_verification_enabled,
             from: mail.from.to_string(),
             reply_to: mail.reply_to.to_string(),
             smtp: Smtp::from(mail.smtp),

--- a/src/web/api/client/v1/contexts/settings/mod.rs
+++ b/src/web/api/client/v1/contexts/settings/mod.rs
@@ -49,7 +49,6 @@ pub struct Network {
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Auth {
-    pub email_on_signup: String,
     pub secret_key: String,
     pub password_constraints: PasswordConstraints,
 }
@@ -154,7 +153,6 @@ impl From<DomainNetwork> for Network {
 impl From<DomainAuth> for Auth {
     fn from(auth: DomainAuth) -> Self {
         Self {
-            email_on_signup: format!("{:?}", auth.email_on_signup),
             secret_key: auth.secret_key.to_string(),
             password_constraints: auth.password_constraints.into(),
         }

--- a/src/web/api/server/v1/contexts/settings/mod.rs
+++ b/src/web/api/server/v1/contexts/settings/mod.rs
@@ -183,7 +183,7 @@
 //!
 //! **Resource**
 //!
-//! Refer to the [`ConfigurationPublic`](crate::config::ConfigurationPublic)
+//! Refer to the [`ConfigurationPublic`](crate::services::settings::ConfigurationPublic)
 //! struct for more information about the response attributes.
 pub mod handlers;
 pub mod routes;

--- a/src/web/api/server/v1/contexts/settings/mod.rs
+++ b/src/web/api/server/v1/contexts/settings/mod.rs
@@ -5,7 +5,6 @@
 //! # Endpoints
 //!
 //! - [Get all settings](#get-all-settings)
-//! - [Update all settings](#update-all-settings)
 //! - [Get site name](#get-site-name)
 //! - [Get public settings](#get-public-settings)
 //!
@@ -97,34 +96,6 @@
 //!   }
 //! }
 //! ```
-//! **Resource**
-//!
-//! Refer to the [`TorrustIndex`](crate::config::Settings)
-//! struct for more information about the response attributes.
-//!
-//! # Update all settings
-//!
-//! **NOTICE**: This endpoint to update the settings does not work when you use
-//! environment variables to configure the application. You need to use a
-//! configuration file instead. Because settings are persisted in that file.
-//! Refer to the issue [#144](https://github.com/torrust/torrust-index/issues/144)
-//! for more information.
-//!
-//! `POST /v1/settings`
-//!
-//! **Example request**
-//!
-//! ```bash
-//! curl \
-//!   --header "Content-Type: application/json" \
-//!   --header "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjp7InVzZXJfaWQiOjEsInVzZXJuYW1lIjoiaW5kZXhhZG1pbiIsImFkbWluaXN0cmF0b3IiOnRydWV9LCJleHAiOjE2ODYyMTU3ODh9.4k8ty27DiWwOk4WVcYEhIrAndhpXMRWnLZ3i_HlJnvI" \
-//!   --request POST \
-//!   --data '{"website":{"name":"Torrust"},"tracker":{"url":"udp://localhost:6969","mode":"public","api_url":"http://localhost:1212/","token":"MyAccessToken","token_valid_seconds":7257600},"net":{"port":3001,"base_url":null},"auth":{"min_password_length":6,"max_password_length":64,"secret_key":"MaxVerstappenWC2021"},"database":{"connect_url":"sqlite://./storage/database/data.db?mode=rwc"},"mail":{"from":"example@email.com","reply_to":"noreply@email.com","username":"","password":"","server":"","port":25},"image_cache":{"max_request_timeout_ms":1000,"capacity":128000000,"entry_size_limit":4000000,"user_quota_period_seconds":3600,"user_quota_bytes":64000000},"api":{"default_torrent_page_size":10,"max_torrent_page_size":30},"tracker_statistics_importer":{"torrent_info_update_interval":3600}}' \
-//!   "http://127.0.0.1:3001/v1/settings"
-//! ```
-//!
-//! The response contains the settings that were updated.
-//!
 //! **Resource**
 //!
 //! Refer to the [`TorrustIndex`](crate::config::Settings)

--- a/src/web/api/server/v1/contexts/settings/mod.rs
+++ b/src/web/api/server/v1/contexts/settings/mod.rs
@@ -30,43 +30,55 @@
 //! ```json
 //! {
 //!   "data": {
+//!     "version": "2",
+//!     "logging": {
+//!       "threshold": "info"
+//!     },
 //!     "website": {
 //!       "name": "Torrust"
 //!     },
 //!     "tracker": {
-//!       "url": "udp://localhost:6969",
-//!       "mode": "public",
 //!       "api_url": "http://localhost:1212/",
-//!       "token": "MyAccessToken",
-//!       "token_valid_seconds": 7257600
+//!       "listed": false,
+//!       "private": false,
+//!       "token": "***",
+//!       "token_valid_seconds": 7257600,
+//!       "url": "udp://localhost:6969"
 //!     },
 //!     "net": {
-//!       "port": 3001,
-//!       "base_url": null
+//!       "base_url": null,
+//!       "bind_address": "0.0.0.0:3001",
+//!       "tsl": null
 //!     },
 //!     "auth": {
-//!       "min_password_length": 6,
-//!       "max_password_length": 64,
-//!       "secret_key": "MaxVerstappenWC2021"
+//!       "secret_key": "***",
+//!       "password_constraints": {
+//!         "max_password_length": 64,
+//!         "min_password_length": 6
+//!       }
 //!     },
 //!     "database": {
-//!       "connect_url": "sqlite://./storage/database/data.db?mode=rwc"
+//!       "connect_url": "sqlite://data.db?mode=rwc"
 //!     },
 //!     "mail": {
 //!       "email_verification_enabled": false,
 //!       "from": "example@email.com",
 //!       "reply_to": "noreply@email.com",
-//!       "username": "",
-//!       "password": "",
-//!       "server": "",
-//!       "port": 25
+//!       "smtp": {
+//!         "port": 25,
+//!         "server": "",
+//!         "credentials": {
+//!           "password": "***",
+//!           "username": ""
+//!         }
+//!       }
 //!     },
 //!     "image_cache": {
-//!       "max_request_timeout_ms": 1000,
 //!       "capacity": 128000000,
 //!       "entry_size_limit": 4000000,
-//!       "user_quota_period_seconds": 3600,
-//!       "user_quota_bytes": 64000000
+//!       "max_request_timeout_ms": 1000,
+//!       "user_quota_bytes": 64000000,
+//!       "user_quota_period_seconds": 3600
 //!     },
 //!     "api": {
 //!       "default_torrent_page_size": 10,
@@ -79,8 +91,8 @@
 //!       }
 //!     },
 //!     "tracker_statistics_importer": {
+//!       "port": 3002,
 //!       "torrent_info_update_interval": 3600
-//!       "port": 3002
 //!     }
 //!   }
 //! }
@@ -107,7 +119,7 @@
 //!   --header "Content-Type: application/json" \
 //!   --header "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjp7InVzZXJfaWQiOjEsInVzZXJuYW1lIjoiaW5kZXhhZG1pbiIsImFkbWluaXN0cmF0b3IiOnRydWV9LCJleHAiOjE2ODYyMTU3ODh9.4k8ty27DiWwOk4WVcYEhIrAndhpXMRWnLZ3i_HlJnvI" \
 //!   --request POST \
-//!   --data '{"website":{"name":"Torrust"},"tracker":{"url":"udp://localhost:6969","mode":"public","api_url":"http://localhost:1212/","token":"MyAccessToken","token_valid_seconds":7257600},"net":{"port":3001,"base_url":null},"auth":{"min_password_length":6,"max_password_length":64,"secret_key":"MaxVerstappenWC2021"},"database":{"connect_url":"sqlite://./storage/database/data.db?mode=rwc"},"mail":{"email_verification_enabled":false,"from":"example@email.com","reply_to":"noreply@email.com","username":"","password":"","server":"","port":25},"image_cache":{"max_request_timeout_ms":1000,"capacity":128000000,"entry_size_limit":4000000,"user_quota_period_seconds":3600,"user_quota_bytes":64000000},"api":{"default_torrent_page_size":10,"max_torrent_page_size":30},"tracker_statistics_importer":{"torrent_info_update_interval":3600}}' \
+//!   --data '{"website":{"name":"Torrust"},"tracker":{"url":"udp://localhost:6969","mode":"public","api_url":"http://localhost:1212/","token":"MyAccessToken","token_valid_seconds":7257600},"net":{"port":3001,"base_url":null},"auth":{"min_password_length":6,"max_password_length":64,"secret_key":"MaxVerstappenWC2021"},"database":{"connect_url":"sqlite://./storage/database/data.db?mode=rwc"},"mail":{"from":"example@email.com","reply_to":"noreply@email.com","username":"","password":"","server":"","port":25},"image_cache":{"max_request_timeout_ms":1000,"capacity":128000000,"entry_size_limit":4000000,"user_quota_period_seconds":3600,"user_quota_bytes":64000000},"api":{"default_torrent_page_size":10,"max_torrent_page_size":30},"tracker_statistics_importer":{"torrent_info_update_interval":3600}}' \
 //!   "http://127.0.0.1:3001/v1/settings"
 //! ```
 //!

--- a/src/web/api/server/v1/contexts/settings/mod.rs
+++ b/src/web/api/server/v1/contexts/settings/mod.rs
@@ -45,7 +45,6 @@
 //!       "base_url": null
 //!     },
 //!     "auth": {
-//!       "email_on_signup": "optional",
 //!       "min_password_length": 6,
 //!       "max_password_length": 64,
 //!       "secret_key": "MaxVerstappenWC2021"
@@ -72,6 +71,12 @@
 //!     "api": {
 //!       "default_torrent_page_size": 10,
 //!       "max_torrent_page_size": 30
+//!     },
+//!     "registration": {
+//!       "email": {
+//!         "required": false,
+//!         "verified": false
+//!       }
 //!     },
 //!     "tracker_statistics_importer": {
 //!       "torrent_info_update_interval": 3600
@@ -102,7 +107,7 @@
 //!   --header "Content-Type: application/json" \
 //!   --header "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjp7InVzZXJfaWQiOjEsInVzZXJuYW1lIjoiaW5kZXhhZG1pbiIsImFkbWluaXN0cmF0b3IiOnRydWV9LCJleHAiOjE2ODYyMTU3ODh9.4k8ty27DiWwOk4WVcYEhIrAndhpXMRWnLZ3i_HlJnvI" \
 //!   --request POST \
-//!   --data '{"website":{"name":"Torrust"},"tracker":{"url":"udp://localhost:6969","mode":"public","api_url":"http://localhost:1212/","token":"MyAccessToken","token_valid_seconds":7257600},"net":{"port":3001,"base_url":null},"auth":{"email_on_signup":"optional","min_password_length":6,"max_password_length":64,"secret_key":"MaxVerstappenWC2021"},"database":{"connect_url":"sqlite://./storage/database/data.db?mode=rwc"},"mail":{"email_verification_enabled":false,"from":"example@email.com","reply_to":"noreply@email.com","username":"","password":"","server":"","port":25},"image_cache":{"max_request_timeout_ms":1000,"capacity":128000000,"entry_size_limit":4000000,"user_quota_period_seconds":3600,"user_quota_bytes":64000000},"api":{"default_torrent_page_size":10,"max_torrent_page_size":30},"tracker_statistics_importer":{"torrent_info_update_interval":3600}}' \
+//!   --data '{"website":{"name":"Torrust"},"tracker":{"url":"udp://localhost:6969","mode":"public","api_url":"http://localhost:1212/","token":"MyAccessToken","token_valid_seconds":7257600},"net":{"port":3001,"base_url":null},"auth":{"min_password_length":6,"max_password_length":64,"secret_key":"MaxVerstappenWC2021"},"database":{"connect_url":"sqlite://./storage/database/data.db?mode=rwc"},"mail":{"email_verification_enabled":false,"from":"example@email.com","reply_to":"noreply@email.com","username":"","password":"","server":"","port":25},"image_cache":{"max_request_timeout_ms":1000,"capacity":128000000,"entry_size_limit":4000000,"user_quota_period_seconds":3600,"user_quota_bytes":64000000},"api":{"default_torrent_page_size":10,"max_torrent_page_size":30},"tracker_statistics_importer":{"torrent_info_update_interval":3600}}' \
 //!   "http://127.0.0.1:3001/v1/settings"
 //! ```
 //!

--- a/src/web/api/server/v1/contexts/user/mod.rs
+++ b/src/web/api/server/v1/contexts/user/mod.rs
@@ -45,7 +45,6 @@
 //!
 //! ```toml
 //! [auth]
-//! email_on_signup = "Optional"
 //! secret_key = "MaxVerstappenWC2021"
 //! ```
 //!

--- a/tests/common/contexts/settings/mod.rs
+++ b/tests/common/contexts/settings/mod.rs
@@ -5,9 +5,10 @@ use std::net::SocketAddr;
 use serde::{Deserialize, Serialize};
 use torrust_index::config::{
     Api as DomainApi, ApiToken, Auth as DomainAuth, Credentials as DomainCredentials, Database as DomainDatabase,
-    ImageCache as DomainImageCache, Logging as DomainLogging, Mail as DomainMail, Network as DomainNetwork,
-    PasswordConstraints as DomainPasswordConstraints, Settings as DomainSettings, Smtp as DomainSmtp, Tracker as DomainTracker,
-    TrackerStatisticsImporter as DomainTrackerStatisticsImporter, Website as DomainWebsite,
+    Email as DomainEmail, ImageCache as DomainImageCache, Logging as DomainLogging, Mail as DomainMail, Network as DomainNetwork,
+    PasswordConstraints as DomainPasswordConstraints, Registration as DomainRegistration, Settings as DomainSettings,
+    Smtp as DomainSmtp, Tracker as DomainTracker, TrackerStatisticsImporter as DomainTrackerStatisticsImporter,
+    Website as DomainWebsite,
 };
 use url::Url;
 
@@ -22,6 +23,7 @@ pub struct Settings {
     pub mail: Mail,
     pub image_cache: ImageCache,
     pub api: Api,
+    pub registration: Option<Registration>,
     pub tracker_statistics_importer: TrackerStatisticsImporter,
 }
 
@@ -53,7 +55,6 @@ pub struct Network {
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Auth {
-    pub email_on_signup: String,
     pub secret_key: String,
     pub password_constraints: PasswordConstraints,
 }
@@ -106,6 +107,17 @@ pub struct Api {
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+pub struct Registration {
+    pub email: Option<Email>,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+pub struct Email {
+    pub required: bool,
+    pub verified: bool,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct TrackerStatisticsImporter {
     pub torrent_info_update_interval: u64,
     port: u16,
@@ -123,6 +135,7 @@ impl From<DomainSettings> for Settings {
             mail: Mail::from(settings.mail),
             image_cache: ImageCache::from(settings.image_cache),
             api: Api::from(settings.api),
+            registration: settings.registration.map(Registration::from),
             tracker_statistics_importer: TrackerStatisticsImporter::from(settings.tracker_statistics_importer),
         }
     }
@@ -167,7 +180,6 @@ impl From<DomainNetwork> for Network {
 impl From<DomainAuth> for Auth {
     fn from(auth: DomainAuth) -> Self {
         Self {
-            email_on_signup: auth.email_on_signup.to_string(),
             secret_key: auth.secret_key.to_string(),
             password_constraints: auth.password_constraints.into(),
         }
@@ -238,6 +250,23 @@ impl From<DomainApi> for Api {
         Self {
             default_torrent_page_size: api.default_torrent_page_size,
             max_torrent_page_size: api.max_torrent_page_size,
+        }
+    }
+}
+
+impl From<DomainRegistration> for Registration {
+    fn from(registration: DomainRegistration) -> Self {
+        Self {
+            email: registration.email.map(Email::from),
+        }
+    }
+}
+
+impl From<DomainEmail> for Email {
+    fn from(email: DomainEmail) -> Self {
+        Self {
+            required: email.required,
+            verified: email.verified,
         }
     }
 }

--- a/tests/common/contexts/settings/mod.rs
+++ b/tests/common/contexts/settings/mod.rs
@@ -72,7 +72,6 @@ pub struct Database {
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Mail {
-    pub email_verification_enabled: bool,
     pub from: String,
     pub reply_to: String,
     pub smtp: Smtp,
@@ -206,7 +205,6 @@ impl From<DomainDatabase> for Database {
 impl From<DomainMail> for Mail {
     fn from(mail: DomainMail) -> Self {
         Self {
-            email_verification_enabled: mail.email_verification_enabled,
             from: mail.from.to_string(),
             reply_to: mail.reply_to.to_string(),
             smtp: mail.smtp.into(),

--- a/tests/e2e/web/api/v1/contexts/settings/contract.rs
+++ b/tests/e2e/web/api/v1/contexts/settings/contract.rs
@@ -1,6 +1,6 @@
 //! API contract for `settings` context.
 
-use torrust_index::config::EmailOnSignup;
+use torrust_index::services::settings::EmailOnSignup;
 use torrust_index::web::api;
 
 use crate::common::asserts::assert_json_ok_response;

--- a/tests/environments/isolated.rs
+++ b/tests/environments/isolated.rs
@@ -2,6 +2,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use tempfile::TempDir;
 use torrust_index::config;
+use torrust_index::config::v2::registration::{Email, Registration};
 use torrust_index::config::{Threshold, FREE_PORT};
 use torrust_index::web::api::Version;
 use url::Url;
@@ -86,6 +87,14 @@ fn ephemeral(temp_dir: &TempDir) -> config::Settings {
     // Ephemeral SQLite database
     configuration.database.connect_url =
         Url::parse(&format!("sqlite://{}?mode=rwc", random_database_file_path_in(temp_dir))).unwrap();
+
+    // Enable user registration
+    configuration.registration = Some(Registration {
+        email: Some(Email {
+            required: false,
+            verified: false,
+        }),
+    });
 
     configuration
 }


### PR DESCRIPTION
Refactor configuration for options related to email in the registration.

### Old version

```toml
[auth]
email_on_signup = "optional"

[mail]
email_verification_enabled = false
```

### New version

Registration Disabled:

```toml
# [registration]
```

Registration without email option:

```toml
[registration]
```

Registration optionally including an email address:

```toml
[registration]
[registration.email]
```

Registration with  email:

```toml
[registration]
[registration.email]
required = true
```

Registration with optional email, but if email is supplied it is verified:

```toml
[registration]
[registration.email]
verified = true
```

Registration with email and email is verified:

```toml
[registration]

[registration.email]
required = true
verified = true
```

### Subtasks

- [x] Add the new section
- [x] Use new values in the code
- [x] Delete old config option