### PR TITLE
fix: [#580] E2E tests failing with MySQL

### DIFF
--- a/contrib/dev-tools/container/e2e/mysql/run-e2e-tests.sh
+++ b/contrib/dev-tools/container/e2e/mysql/run-e2e-tests.sh
@@ -41,7 +41,7 @@ docker ps
 # Run E2E tests with shared app instance
 TORRUST_INDEX_E2E_SHARED=true \
     TORRUST_INDEX_CONFIG_TOML_PATH="./share/default/config/index.public.e2e.container.mysql.toml" \
-    TORRUST_INDEX_E2E_DB_CONNECT_URL="mysql://root:root_secret_password@localhost:3306/torrust_index_e2e_testing" \
+    TORRUST_INDEX_E2E_DB_CONNECT_URL="mysql://root:root_secret_password@127.0.0.1:3306/torrust_index_e2e_testing" \
     cargo test ||
     {
         ./contrib/dev-tools/container/e2e/mysql/e2e-env-down.sh

--- a/tests/environments/shared.rs
+++ b/tests/environments/shared.rs
@@ -36,7 +36,7 @@ impl TestEnv {
 impl Default for TestEnv {
     fn default() -> Self {
         Self {
-            authority: "localhost:3001".to_string(),
+            authority: "127.0.0.1:3001".to_string(),
         }
     }
 }


### PR DESCRIPTION
This seems to fix the issue running E2E tests with MySQL on a GitHub runner, but I'm not sure. I've executed the tests twice.