### PR TITLE
Improve metadata section in configuration

### DIFF
--- a/share/default/config/index.container.mysql.toml
+++ b/share/default/config/index.container.mysql.toml
@@ -1,4 +1,7 @@
-version = "2"
+[metadata]
+app = "torrust-index"
+purpose = "configuration"
+schema_version = "2.0.0"
 
 [logging]
 #threshold = "off"

--- a/share/default/config/index.container.sqlite3.toml
+++ b/share/default/config/index.container.sqlite3.toml
@@ -1,4 +1,7 @@
-version = "2"
+[metadata]
+app = "torrust-index"
+purpose = "configuration"
+schema_version = "2.0.0"
 
 [logging]
 #threshold = "off"

--- a/share/default/config/index.development.sqlite3.toml
+++ b/share/default/config/index.development.sqlite3.toml
@@ -1,4 +1,7 @@
-version = "2"
+[metadata]
+app = "torrust-index"
+purpose = "configuration"
+schema_version = "2.0.0"
 
 [logging]
 #threshold = "off"

--- a/share/default/config/index.private.e2e.container.sqlite3.toml
+++ b/share/default/config/index.private.e2e.container.sqlite3.toml
@@ -1,4 +1,7 @@
-version = "2"
+[metadata]
+app = "torrust-index"
+purpose = "configuration"
+schema_version = "2.0.0"
 
 [logging]
 #threshold = "off"

--- a/share/default/config/index.public.e2e.container.mysql.toml
+++ b/share/default/config/index.public.e2e.container.mysql.toml
@@ -1,4 +1,7 @@
-version = "2"
+[metadata]
+app = "torrust-index"
+purpose = "configuration"
+schema_version = "2.0.0"
 
 [logging]
 #threshold = "off"

--- a/share/default/config/index.public.e2e.container.sqlite3.toml
+++ b/share/default/config/index.public.e2e.container.sqlite3.toml
@@ -1,4 +1,7 @@
-version = "2"
+[metadata]
+app = "torrust-index"
+purpose = "configuration"
+schema_version = "2.0.0"
 
 [logging]
 #threshold = "off"

--- a/src/config/v2/mod.rs
+++ b/src/config/v2/mod.rs
@@ -31,7 +31,6 @@ use super::Metadata;
 pub struct Settings {
     /// Configuration metadata.
     #[serde(default = "Settings::default_metadata")]
-    #[serde(flatten)]
     pub metadata: Metadata,
 
     /// The logging configuration.

--- a/src/web/api/server/v1/contexts/settings/mod.rs
+++ b/src/web/api/server/v1/contexts/settings/mod.rs
@@ -29,7 +29,11 @@
 //! ```json
 //! {
 //!   "data": {
-//!     "version": "2",
+//!     "metadata": {
+//!        "app": "torrust-index",
+//!        "purpose": "configuration",
+//!        "schema_version": "2.0.0"
+//!     },
 //!     "logging": {
 //!       "threshold": "info"
 //!     },


### PR DESCRIPTION
We made the same change in the Tracker.

```toml
[metadata]
app = "torrust-index"
purpose = "configuration"
schema_version = "2.0.0"
```