### PR TITLE
Rename config option `secret_key` to `user_claim_token_pepper`

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,7 +25,7 @@ pub type Registration = v2::registration::Registration;
 pub type Email = v2::registration::Email;
 
 pub type Auth = v2::auth::Auth;
-pub type SecretKey = v2::auth::SecretKey;
+pub type SecretKey = v2::auth::ClaimTokenPepper;
 pub type PasswordConstraints = v2::auth::PasswordConstraints;
 
 pub type Database = v2::database::Database;
@@ -376,7 +376,7 @@ mod tests {
                                 bind_address = "0.0.0.0:3001"
 
                                 [auth]
-                                secret_key = "MaxVerstappenWC2021"
+                                user_claim_token_pepper = "MaxVerstappenWC2021"
 
                                 [auth.password_constraints]
                                 max_password_length = 64
@@ -496,12 +496,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn configuration_should_allow_to_override_the_authentication_secret_key_provided_in_the_toml_file() {
+    async fn configuration_should_allow_to_override_the_authentication_user_claim_token_pepper_provided_in_the_toml_file() {
         figment::Jail::expect_with(|jail| {
             jail.create_dir("templates")?;
             jail.create_file("templates/verify.html", "EMAIL TEMPLATE")?;
 
-            jail.set_env("TORRUST_INDEX_CONFIG_OVERRIDE_AUTH__SECRET_KEY", "OVERRIDDEN AUTH SECRET KEY");
+            jail.set_env(
+                "TORRUST_INDEX_CONFIG_OVERRIDE_AUTH__USER_CLAIM_TOKEN_PEPPER",
+                "OVERRIDDEN AUTH SECRET KEY",
+            );
 
             let info = Info {
                 config_toml: Some(default_config_toml()),
@@ -510,7 +513,10 @@ mod tests {
 
             let settings = Configuration::load_settings(&info).expect("Could not load configuration from file");
 
-            assert_eq!(settings.auth.secret_key, SecretKey::new("OVERRIDDEN AUTH SECRET KEY"));
+            assert_eq!(
+                settings.auth.user_claim_token_pepper,
+                SecretKey::new("OVERRIDDEN AUTH SECRET KEY")
+            );
 
             Ok(())
         });

--- a/src/config/v2/auth.rs
+++ b/src/config/v2/auth.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Auth {
     /// The secret key used to sign JWT tokens.
-    #[serde(default = "Auth::default_secret_key")]
-    pub secret_key: SecretKey,
+    #[serde(default = "Auth::default_user_claim_token_pepper")]
+    pub user_claim_token_pepper: ClaimTokenPepper,
 
     /// The password constraints
     #[serde(default = "Auth::default_password_constraints")]
@@ -18,18 +18,18 @@ impl Default for Auth {
     fn default() -> Self {
         Self {
             password_constraints: Self::default_password_constraints(),
-            secret_key: Self::default_secret_key(),
+            user_claim_token_pepper: Self::default_user_claim_token_pepper(),
         }
     }
 }
 
 impl Auth {
-    pub fn override_secret_key(&mut self, secret_key: &str) {
-        self.secret_key = SecretKey::new(secret_key);
+    pub fn override_user_claim_token_pepper(&mut self, user_claim_token_pepper: &str) {
+        self.user_claim_token_pepper = ClaimTokenPepper::new(user_claim_token_pepper);
     }
 
-    fn default_secret_key() -> SecretKey {
-        SecretKey::new("MaxVerstappenWC2021")
+    fn default_user_claim_token_pepper() -> ClaimTokenPepper {
+        ClaimTokenPepper::new("MaxVerstappenWC2021")
     }
 
     fn default_password_constraints() -> PasswordConstraints {
@@ -38,9 +38,9 @@ impl Auth {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct SecretKey(String);
+pub struct ClaimTokenPepper(String);
 
-impl SecretKey {
+impl ClaimTokenPepper {
     /// # Panics
     ///
     /// Will panic if the key if empty.
@@ -57,7 +57,7 @@ impl SecretKey {
     }
 }
 
-impl fmt::Display for SecretKey {
+impl fmt::Display for ClaimTokenPepper {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -94,11 +94,11 @@ impl PasswordConstraints {
 
 #[cfg(test)]
 mod tests {
-    use super::SecretKey;
+    use super::ClaimTokenPepper;
 
     #[test]
     #[should_panic(expected = "secret key cannot be empty")]
     fn secret_key_can_not_be_empty() {
-        drop(SecretKey::new(""));
+        drop(ClaimTokenPepper::new(""));
     }
 }

--- a/src/config/v2/mod.rs
+++ b/src/config/v2/mod.rs
@@ -15,7 +15,7 @@ use registration::Registration;
 use serde::{Deserialize, Serialize};
 
 use self::api::Api;
-use self::auth::{Auth, SecretKey};
+use self::auth::{Auth, ClaimTokenPepper};
 use self::database::Database;
 use self::image_cache::ImageCache;
 use self::mail::Mail;
@@ -104,7 +104,7 @@ impl Settings {
             let _ = self.database.connect_url.set_password(Some("***"));
         }
         "***".clone_into(&mut self.mail.smtp.credentials.password);
-        self.auth.secret_key = SecretKey::new("***");
+        self.auth.user_claim_token_pepper = ClaimTokenPepper::new("***");
     }
 
     /// Encodes the configuration to TOML.

--- a/src/config/v2/tracker.rs
+++ b/src/config/v2/tracker.rs
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "tracker API token cannot be empty")]
-    fn secret_key_can_not_be_empty() {
+    fn apai_token_can_not_be_empty() {
         drop(ApiToken::new(""));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@
 //! bind_address = "0.0.0.0:3001"
 //!
 //! [auth]
-//! secret_key = "MaxVerstappenWC2021"
+//! user_claim_token_pepper = "MaxVerstappenWC2021"
 //!
 //! [auth.password_constraints]
 //! min_password_length = 6

--- a/src/mailer.rs
+++ b/src/mailer.rs
@@ -133,7 +133,7 @@ impl Service {
         let settings = self.cfg.settings.read().await;
 
         // create verification JWT
-        let key = settings.auth.secret_key.as_bytes();
+        let key = settings.auth.user_claim_token_pepper.as_bytes();
 
         // Create non expiring token that is only valid for email-verification
         let claims = VerifyClaims {

--- a/src/services/authentication.rs
+++ b/src/services/authentication.rs
@@ -134,7 +134,7 @@ impl JsonWebToken {
         let settings = self.cfg.settings.read().await;
 
         // Create JWT that expires in two weeks
-        let key = settings.auth.secret_key.as_bytes();
+        let key = settings.auth.user_claim_token_pepper.as_bytes();
 
         // todo: create config option for setting the token validity in seconds.
         let exp_date = clock::now() + 1_209_600; // two weeks from now
@@ -154,7 +154,7 @@ impl JsonWebToken {
 
         match decode::<UserClaims>(
             token,
-            &DecodingKey::from_secret(settings.auth.secret_key.as_bytes()),
+            &DecodingKey::from_secret(settings.auth.user_claim_token_pepper.as_bytes()),
             &Validation::new(Algorithm::HS256),
         ) {
             Ok(token_data) => {

--- a/src/services/user.rs
+++ b/src/services/user.rs
@@ -172,7 +172,7 @@ impl RegistrationService {
 
         let token_data = match decode::<VerifyClaims>(
             token,
-            &DecodingKey::from_secret(settings.auth.secret_key.as_bytes()),
+            &DecodingKey::from_secret(settings.auth.user_claim_token_pepper.as_bytes()),
             &Validation::new(Algorithm::HS256),
         ) {
             Ok(token_data) => {

--- a/src/web/api/client/v1/contexts/settings/mod.rs
+++ b/src/web/api/client/v1/contexts/settings/mod.rs
@@ -49,7 +49,7 @@ pub struct Network {
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Auth {
-    pub secret_key: String,
+    pub user_claim_token_pepper: String,
     pub password_constraints: PasswordConstraints,
 }
 
@@ -152,7 +152,7 @@ impl From<DomainNetwork> for Network {
 impl From<DomainAuth> for Auth {
     fn from(auth: DomainAuth) -> Self {
         Self {
-            secret_key: auth.secret_key.to_string(),
+            user_claim_token_pepper: auth.user_claim_token_pepper.to_string(),
             password_constraints: auth.password_constraints.into(),
         }
     }

--- a/src/web/api/server/v1/contexts/settings/mod.rs
+++ b/src/web/api/server/v1/contexts/settings/mod.rs
@@ -54,7 +54,7 @@
 //!       "tsl": null
 //!     },
 //!     "auth": {
-//!       "secret_key": "***",
+//!       "user_claim_token_pepper": "***",
 //!       "password_constraints": {
 //!         "max_password_length": 64,
 //!         "min_password_length": 6

--- a/src/web/api/server/v1/contexts/user/mod.rs
+++ b/src/web/api/server/v1/contexts/user/mod.rs
@@ -45,7 +45,7 @@
 //!
 //! ```toml
 //! [auth]
-//! secret_key = "MaxVerstappenWC2021"
+//! user_claim_token_pepper = "MaxVerstappenWC2021"
 //! ```
 //!
 //! Refer to the [`RegistrationForm`](crate::web::api::server::v1::contexts::user::forms::RegistrationForm)

--- a/tests/common/contexts/settings/mod.rs
+++ b/tests/common/contexts/settings/mod.rs
@@ -55,7 +55,7 @@ pub struct Network {
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Auth {
-    pub secret_key: String,
+    pub user_claim_token_pepper: String,
     pub password_constraints: PasswordConstraints,
 }
 
@@ -179,7 +179,7 @@ impl From<DomainNetwork> for Network {
 impl From<DomainAuth> for Auth {
     fn from(auth: DomainAuth) -> Self {
         Self {
-            secret_key: auth.secret_key.to_string(),
+            user_claim_token_pepper: auth.user_claim_token_pepper.to_string(),
             password_constraints: auth.password_constraints.into(),
         }
     }

--- a/tests/e2e/environment.rs
+++ b/tests/e2e/environment.rs
@@ -114,7 +114,7 @@ impl TestEnv {
 
                 "***".clone_into(&mut settings.mail.smtp.credentials.password);
 
-                "***".clone_into(&mut settings.auth.secret_key);
+                "***".clone_into(&mut settings.auth.user_claim_token_pepper);
 
                 Some(settings)
             }


### PR DESCRIPTION
It's used to sign the Json Web Token. `secret_key` was too generic.