### PR TITLE
Feat: allow overwriting casbin configuration

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -9,6 +9,7 @@ binascii
 btih
 buildx
 camino
+Casbin
 chrono
 clippy
 codecov
@@ -51,6 +52,7 @@ luckythelab
 mailcatcher
 mandelbrotset
 metainfo
+Mgmt
 migth
 nanos
 NCCA

--- a/src/config/v2/mod.rs
+++ b/src/config/v2/mod.rs
@@ -8,11 +8,13 @@ pub mod net;
 pub mod registration;
 pub mod tracker;
 pub mod tracker_statistics_importer;
+pub mod unstable;
 pub mod website;
 
 use logging::Logging;
 use registration::Registration;
 use serde::{Deserialize, Serialize};
+use unstable::Unstable;
 
 use self::api::Api;
 use self::auth::{Auth, ClaimTokenPepper};
@@ -76,6 +78,10 @@ pub struct Settings {
     /// The tracker statistics importer job configuration.
     #[serde(default = "Settings::default_tracker_statistics_importer")]
     pub tracker_statistics_importer: TrackerStatisticsImporter,
+
+    /// The unstable configuration.
+    #[serde(default = "Settings::default_unstable")]
+    pub unstable: Option<Unstable>,
 }
 
 impl Default for Settings {
@@ -93,6 +99,7 @@ impl Default for Settings {
             api: Self::default_api(),
             registration: Self::default_registration(),
             tracker_statistics_importer: Self::default_tracker_statistics_importer(),
+            unstable: Self::default_unstable(),
         }
     }
 }
@@ -173,6 +180,10 @@ impl Settings {
 
     fn default_tracker_statistics_importer() -> TrackerStatisticsImporter {
         TrackerStatisticsImporter::default()
+    }
+
+    fn default_unstable() -> Option<Unstable> {
+        None
     }
 }
 

--- a/src/config/v2/unstable.rs
+++ b/src/config/v2/unstable.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+/// Unstable configuration options.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Unstable {
+    /// The casbin configuration used for authorization.
+    #[serde(default = "Unstable::default_auth")]
+    pub auth: Option<Auth>,
+}
+
+impl Default for Unstable {
+    fn default() -> Self {
+        Self {
+            auth: Self::default_auth(),
+        }
+    }
+}
+
+impl Unstable {
+    fn default_auth() -> Option<Auth> {
+        None
+    }
+}
+
+/// Unstable auth configuration options.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Auth {
+    /// The casbin configuration used for authorization.
+    #[serde(default = "Auth::default_casbin")]
+    pub casbin: Option<Casbin>,
+}
+
+impl Default for Auth {
+    fn default() -> Self {
+        Self {
+            casbin: Self::default_casbin(),
+        }
+    }
+}
+
+impl Auth {
+    fn default_casbin() -> Option<Casbin> {
+        None
+    }
+}
+
+/// Authentication options.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Casbin {
+    /// The model. See <https://casbin.org>.
+    pub model: String,
+
+    /// The policy. See <https://casbin.org>.
+    pub policy: String,
+}


### PR DESCRIPTION
This is an **unstable** feature. You can overwrite casbin configuration to change permissions for roles:  guest, registered and admin.

You can do it by adding this new section to the TOML config file:

```toml
[unstable.auth.casbin]
model = """
[request_definition]
r = role, action

[policy_definition]
p = role, action

[policy_effect]
e = some(where (p.eft == allow))

[matchers]
m = r.role == p.role && r.action == p.action
"""

policy = """
admin, GetAboutPage
admin, GetLicensePage
admin, AddCategory
admin, DeleteCategory
admin, GetCategories
admin, GetImageByUrl
admin, GetSettings
admin, GetSettingsSecret
admin, GetPublicSettings
admin, AddTag
admin, DeleteTag
admin, GetTags
admin, AddTorrent
admin, GetTorrent
admin, DeleteTorrent
admin, GetTorrentInfo
admin, GenerateTorrentInfoListing
admin, GetCanonicalInfoHash
admin, ChangePassword
admin, BanUser
registered, GetAboutPage
registered, GetLicensePage
registered, GetCategories
registered, GetImageByUrl
registered, GetPublicSettings
registered, GetTags
registered, AddTorrent
registered, GetTorrent
registered, GetTorrentInfo
registered, GenerateTorrentInfoListing
registered, GetCanonicalInfoHash
registered, ChangePassword
guest, GetAboutPage
guest, GetLicensePage
guest, GetCategories
guest, GetPublicSettings
guest, GetTags
guest, GetTorrent
guest, GetTorrentInfo
guest, GenerateTorrentInfoListing
guest, GetCanonicalInfoHash
"""
```

For example, if you want to force users to log in to see the torrent list, you can remove the following line from the policy:

```
guest, GenerateTorrentInfoListing
```

**NOTICE**: This is an unstable feature. It will panic with wrong casbin configuration, invalid roles, etcetera.