### PR TITLE
 Fix unhandled errors on maybe_user_id unwraps in authorization logic

### DIFF
--- a/src/services/proxy.rs
+++ b/src/services/proxy.rs
@@ -38,10 +38,6 @@ impl Service {
     /// * The image URL is not an image.
     /// * The image is too big.
     /// * The user quota is met.
-    ///
-    /// # Panics
-    ///
-    /// The function panics if the optional user id has no value
     pub async fn get_image_by_url(&self, url: &str, maybe_user_id: Option<UserId>) -> Result<Bytes, Error> {
         let Some(user_id) = maybe_user_id else {
             return Err(Error::Unauthenticated);

--- a/src/services/proxy.rs
+++ b/src/services/proxy.rs
@@ -38,7 +38,6 @@ impl Service {
     /// * The image URL is not an image.
     /// * The image is too big.
     /// * The user quota is met.
-    #[allow(clippy::missing_panics_doc)]
     pub async fn get_image_by_url(&self, url: &str, maybe_user_id: Option<UserId>) -> Result<Bytes, Error> {
         self.authorization_service
             .authorize(ACTION::GetImageByUrl, maybe_user_id)

--- a/src/services/proxy.rs
+++ b/src/services/proxy.rs
@@ -43,13 +43,15 @@ impl Service {
     ///
     /// The function panics if the optional user id has no value
     pub async fn get_image_by_url(&self, url: &str, maybe_user_id: Option<UserId>) -> Result<Bytes, Error> {
+        let Some(user_id) = maybe_user_id else {
+            return Err(Error::Unauthenticated);
+        };
+
         self.authorization_service
             .authorize(ACTION::GetImageByUrl, maybe_user_id)
             .await
             .map_err(|_| Error::Unauthenticated)?;
 
-        self.image_cache_service
-            .get_image_by_url(url, maybe_user_id.expect("There is no user id needed to perform the action"))
-            .await
+        self.image_cache_service.get_image_by_url(url, user_id).await
     }
 }

--- a/src/services/proxy.rs
+++ b/src/services/proxy.rs
@@ -38,13 +38,18 @@ impl Service {
     /// * The image URL is not an image.
     /// * The image is too big.
     /// * The user quota is met.
+    ///
+    /// # Panics
+    ///
+    /// The function panics if the optional user id has no value
     pub async fn get_image_by_url(&self, url: &str, maybe_user_id: Option<UserId>) -> Result<Bytes, Error> {
         self.authorization_service
             .authorize(ACTION::GetImageByUrl, maybe_user_id)
             .await
             .map_err(|_| Error::Unauthenticated)?;
 
-        // The unwrap should never panic as if the maybe_user_id is none, an authorization error will be returned and handled at the method above
-        self.image_cache_service.get_image_by_url(url, maybe_user_id.unwrap()).await
+        self.image_cache_service
+            .get_image_by_url(url, maybe_user_id.expect("There is no user id needed to perform the action"))
+            .await
     }
 }

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -135,6 +135,10 @@ impl Index {
         add_torrent_req: AddTorrentRequest,
         maybe_user_id: Option<UserId>,
     ) -> Result<AddTorrentResponse, ServiceError> {
+        let Some(user_id) = maybe_user_id else {
+            return Err(ServiceError::UnauthorizedActionForGuests);
+        };
+
         self.authorization_service
             .authorize(ACTION::AddTorrent, maybe_user_id)
             .await?;
@@ -150,12 +154,7 @@ impl Index {
 
         let torrent_id = self
             .torrent_repository
-            .add(
-                &original_info_hash,
-                &torrent,
-                &metadata,
-                maybe_user_id.expect("There is no user id needed to perform the action"),
-            )
+            .add(&original_info_hash, &torrent, &metadata, user_id)
             .await?;
 
         // Synchronous secondary tasks

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -129,6 +129,7 @@ impl Index {
     /// This function will panic if:
     ///
     /// * Unable to parse the torrent info-hash.
+    /// * The optional user id has no value
     pub async fn add_torrent(
         &self,
         add_torrent_req: AddTorrentRequest,
@@ -149,7 +150,12 @@ impl Index {
 
         let torrent_id = self
             .torrent_repository
-            .add(&original_info_hash, &torrent, &metadata, maybe_user_id.unwrap())
+            .add(
+                &original_info_hash,
+                &torrent,
+                &metadata,
+                maybe_user_id.expect("There is no user id needed to perform the action"),
+            )
             .await?;
 
         // Synchronous secondary tasks

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -129,7 +129,6 @@ impl Index {
     /// This function will panic if:
     ///
     /// * Unable to parse the torrent info-hash.
-    /// * The optional user id has no value
     pub async fn add_torrent(
         &self,
         add_torrent_req: AddTorrentRequest,

--- a/src/services/user.rs
+++ b/src/services/user.rs
@@ -227,9 +227,6 @@ impl ProfileService {
     /// * An error if unable to successfully hash the password.
     /// * An error if unable to change the password in the database.
     /// * An error if it is not possible to authorize the action
-    /// # Panics
-    ///
-    /// The function panics if the optional user id has no value
     pub async fn change_password(
         &self,
         maybe_user_id: Option<UserId>,
@@ -304,9 +301,6 @@ impl BanService {
     /// * `ServiceError::InternalServerError` if unable get user from the request.
     /// * An error if unable to get user profile from supplied username.
     /// * An error if unable to set the ban of the user in the database.
-    /// # Panics
-    ///
-    /// The function panics if the optional user id has no value
     pub async fn ban_user(&self, username_to_be_banned: &str, maybe_user_id: Option<UserId>) -> Result<(), ServiceError> {
         let Some(user_id) = maybe_user_id else {
             return Err(ServiceError::UnauthorizedActionForGuests);

--- a/src/services/user.rs
+++ b/src/services/user.rs
@@ -227,7 +227,6 @@ impl ProfileService {
     /// * An error if unable to successfully hash the password.
     /// * An error if unable to change the password in the database.
     /// * An error if it is not possible to authorize the action
-    #[allow(clippy::missing_panics_doc)]
     pub async fn change_password(
         &self,
         maybe_user_id: Option<UserId>,
@@ -298,7 +297,6 @@ impl BanService {
     /// * `ServiceError::InternalServerError` if unable get user from the request.
     /// * An error if unable to get user profile from supplied username.
     /// * An error if unable to set the ban of the user in the database.
-    #[allow(clippy::missing_panics_doc)]
     pub async fn ban_user(&self, username_to_be_banned: &str, maybe_user_id: Option<UserId>) -> Result<(), ServiceError> {
         debug!(
             "user with ID {} banning username: {username_to_be_banned}",

--- a/src/web/api/server/v1/contexts/user/handlers.rs
+++ b/src/web/api/server/v1/contexts/user/handlers.rs
@@ -131,7 +131,6 @@ pub async fn renew_token_handler(
 ///
 /// - The user account is not found.
 #[allow(clippy::unused_async)]
-#[allow(clippy::missing_panics_doc)]
 pub async fn change_password_handler(
     State(app_data): State<Arc<AppData>>,
     ExtractOptionalLoggedInUser(maybe_user_id): ExtractOptionalLoggedInUser,

--- a/src/web/api/server/v1/contexts/user/handlers.rs
+++ b/src/web/api/server/v1/contexts/user/handlers.rs
@@ -145,10 +145,7 @@ pub async fn change_password_handler(
         .await
     {
         Ok(()) => Json(OkResponseData {
-            data: format!(
-                "Password changed for user with ID: {}",
-                maybe_user_id.expect("There is no user id needed to perform the action")
-            ),
+            data: format!("Password changed for user with ID: {}", maybe_user_id.unwrap()),
         })
         .into_response(),
         Err(error) => error.into_response(),

--- a/src/web/api/server/v1/contexts/user/handlers.rs
+++ b/src/web/api/server/v1/contexts/user/handlers.rs
@@ -130,10 +130,8 @@ pub async fn renew_token_handler(
 /// It returns an error if:
 ///
 /// - The user account is not found.
-/// # Panics
-///
-/// The function panics if the optional user id has no value
 #[allow(clippy::unused_async)]
+#[allow(clippy::missing_panics_doc)]
 pub async fn change_password_handler(
     State(app_data): State<Arc<AppData>>,
     ExtractOptionalLoggedInUser(maybe_user_id): ExtractOptionalLoggedInUser,

--- a/src/web/api/server/v1/contexts/user/handlers.rs
+++ b/src/web/api/server/v1/contexts/user/handlers.rs
@@ -130,6 +130,9 @@ pub async fn renew_token_handler(
 /// It returns an error if:
 ///
 /// - The user account is not found.
+/// # Panics
+///
+/// The function panics if the optional user id has no value
 #[allow(clippy::unused_async)]
 pub async fn change_password_handler(
     State(app_data): State<Arc<AppData>>,
@@ -142,7 +145,10 @@ pub async fn change_password_handler(
         .await
     {
         Ok(()) => Json(OkResponseData {
-            data: format!("Password changed for user with ID: {}", maybe_user_id.unwrap()),
+            data: format!(
+                "Password changed for user with ID: {}",
+                maybe_user_id.expect("There is no user id needed to perform the action")
+            ),
         })
         .into_response(),
         Err(error) => error.into_response(),


### PR DESCRIPTION
There are several unwraps that lack error handling in the authorization logic when unwrapping the maybe_user_id variable, this PR fix that by handling the errors.