### PR TITLE
chore: synchronize version with tracker 3.0.0-alpha.12-develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-index"
-version = "3.0.0-alpha.3-develop"
+version = "3.0.0-alpha.12-develop"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-index-located-error"
-version = "3.0.0-alpha.3-develop"
+version = "3.0.0-alpha.12-develop"
 dependencies = [
  "thiserror",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ license = "AGPL-3.0-only"
 publish = true
 repository = "https://github.com/torrust/torrust-tracker"
 rust-version = "1.72"
-version = "3.0.0-alpha.3-develop"
+version = "3.0.0-alpha.12-develop"
 
 [profile.dev.package.sqlx-macros]
 opt-level = 3
@@ -88,7 +88,7 @@ text-to-png = "0"
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 toml = "0"
-torrust-index-located-error = { version = "3.0.0-alpha.3-develop", path = "packages/located-error" }
+torrust-index-located-error = { version = "3.0.0-alpha.12-develop", path = "packages/located-error" }
 tower = { version = "0.4", features = ["timeout"] }
 tower-http = { version = "0", features = ["compression-full", "cors", "propagate-header", "request-id", "trace"] }
 trace = "0.1.7"


### PR DESCRIPTION
I'm releasing the version `3.0.0-alpha.12` for all Tracker, Index and Index GUI packages following the [release plan](https://github.com/torrust/torrust-index/wiki/Releases).