### PR TITLE
Fix bug wrong error message for password too long error

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,7 +55,7 @@ pub enum ServiceError {
 
     #[display(fmt = "Password too short")]
     PasswordTooShort,
-    #[display(fmt = "Username too long")]
+    #[display(fmt = "Password too long")]
     PasswordTooLong,
     #[display(fmt = "Passwords don't match")]
     PasswordsDontMatch,


### PR DESCRIPTION
Fix bug wrong error message for password too long error.