### PR TITLE
Fix bug wrong error message for password too long error

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,7 +55,7 @@ pub enum ServiceError {
 
     #[display(fmt = "Password too short")]
     PasswordTooShort,
-    #[display(fmt = "Username too long")]
+    #[display(fmt = "Password too long")]
     PasswordTooLong,
     #[display(fmt = "Passwords don't match")]
     PasswordsDontMatch,

--- a/src/services/user.rs
+++ b/src/services/user.rs
@@ -461,11 +461,11 @@ fn validate_password_constraints(
 
     let password_length = password.len();
 
-    if password_length <= password_rules.min_password_length {
+    if password_length < password_rules.min_password_length {
         return Err(ServiceError::PasswordTooShort);
     }
 
-    if password_length >= password_rules.max_password_length {
+    if password_length > password_rules.max_password_length {
         return Err(ServiceError::PasswordTooLong);
     }
 


### PR DESCRIPTION
Fix bug wrong error message for password too long error.