### PR TITLE
build(deps)!: refresh every dependency to its newest release under the 1.89 floor

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Phase 9 §9.1.3 — guard against re-introducing the
       # `mailcatcher` dev sidecar (or any SMTP/mail config)
@@ -135,7 +135,7 @@ jobs:
 
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: compose
         name: Compose

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install LLVM tools
         run: sudo apt-get update && sudo apt-get install -y llvm
@@ -37,7 +37,7 @@ jobs:
 
       - id: tools
         name: Install Tools
-        uses: taiki-e/install-action@v2.87.2
+        uses: taiki-e/install-action@v2.87.9
         with:
           tool: grcov,cargo-llvm-cov
 
@@ -53,7 +53,7 @@ jobs:
 
       - id: upload
         name: Upload Coverage Report
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/deployment-packages.yaml
+++ b/.github/workflows/deployment-packages.yaml
@@ -103,7 +103,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -124,7 +124,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -58,7 +58,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/generate_coverage_pr.yaml
+++ b/.github/workflows/generate_coverage_pr.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install LLVM tools
         run: sudo apt-get update && sudo apt-get install -y llvm
@@ -37,7 +37,7 @@ jobs:
 
       - id: tools
         name: Install Tools
-        uses: taiki-e/install-action@v2.87.2
+        uses: taiki-e/install-action@v2.87.9
         with:
           tool: grcov,cargo-llvm-cov
 

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: sync
         name: Apply Labels from File

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -40,7 +40,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: msrv
         name: Read MSRV from Cargo.toml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -103,7 +103,7 @@ jobs:
 
       - id: tools
         name: Install Tools
-        uses: taiki-e/install-action@v2.87.2
+        uses: taiki-e/install-action@v2.87.9
         with:
           tool: cargo-machete
 
@@ -141,7 +141,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -178,7 +178,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/upload_coverage_pr.yaml
+++ b/.github/workflows/upload_coverage_pr.yaml
@@ -96,13 +96,13 @@ jobs:
           echo "override_commit=$(<commit_sha.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.parse_previous_artifacts.outputs.override_commit || '' }}
           path: repo_root
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,6 +452,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `IntoResponse` impl for `database::Error` (now handled by domain
   errors).
 
+### Dependencies
+
+- Every dependency of the workspace refreshed to its newest release, majors included. The lock moved to the newest versions the existing requirements admitted, and six requirements crossed a major: `bittorrent-primitives` 0.2 is replaced by `torrust-info-hash` 0.2, the crate its own 0.3 release deprecates the whole of itself in favour of; `jsonwebtoken` 10 to 11; `tower-http` 0.6 to 0.7; `argon2` 0.5 to 0.6 together with `pbkdf2` 0.12 to 0.13, which share a `password-hash` release and cannot move apart; and `tera` 1 to 2. No user-visible behaviour moves: the HTTP API, its responses, the JWT format, the email template language and the on-disk and on-wire form of infohashes are all unchanged. Stored password hashes keep verifying — the PHC string carries the algorithm, version, parameters and salt each hash was written with, so credentials created under the previous releases are read back with their own parameters and remain valid; this is not a breaking change for deployments. `sqlx` stays at 0.8 because 0.9 requires Rust 1.94, above this project's 1.89 floor.
+- Requirements of the bare form `0`, which admit every breaking pre-1.0 release, are narrowed to the `0.x` line the sources are written against, so the manifests now declare what the code actually depends on.
+
 ### Security
 
 - Dev-only ports (MySQL 3306, tracker 6969/7070/1212, mailcatcher

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,13 +139,13 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+checksum = "134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.1",
  "password-hash",
 ]
 
@@ -347,11 +347,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -579,6 +579,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -818,6 +824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +988,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1521,7 +1537,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1531,6 +1547,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2020,7 +2045,7 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -2534,25 +2559,24 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
+ "getrandom 0.4.3",
+ "phc",
 ]
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest 0.10.7",
- "hmac",
+ "digest 0.11.3",
+ "hmac 0.13.0",
  "password-hash",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2643,6 +2667,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e"
 dependencies = [
  "pest",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
+ "getrandom 0.4.3",
 ]
 
 [[package]]
@@ -3097,7 +3132,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3746,7 +3781,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -3785,7 +3820,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,16 +403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
-dependencies = [
- "memchr",
- "serde_core",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,30 +1413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "globset"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags 2.13.2",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,22 +1792,6 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]
@@ -2626,48 +2576,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc5a242e25ed4e7704d0be240f2cfbe20a8c27e7e252d94835be93d92dc39f"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abf21475cc3820fe4b2ca2dc2142902f67a02189f3b5b3a229f4febc01a43e5"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "phc"
@@ -3972,18 +3880,11 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.20.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
+checksum = "52fca06a22977165c6821c26e2bf0387cd7e0822107a6854d5fbb787307c4194"
 dependencies = [
- "globwalk",
- "lazy_static",
- "pest",
- "pest_derive",
- "regex",
  "serde",
- "serde_json",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -4561,12 +4462,6 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uncased"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,7 +3083,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4252,7 +4252,7 @@ dependencies = [
  "torrust-index-render-text-as-image",
  "torrust-info-hash",
  "tower",
- "tower-http",
+ "tower-http 0.7.1",
  "tracing",
  "url",
  "urlencoding",
@@ -4388,21 +4388,37 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "async-compression",
  "bitflags 2.13.2",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a05a66a4fdd61cbbe0a1d755ffe0ca6aba159dd4820936a0ff8a8278245b9c"
+dependencies = [
+ "async-compression",
+ "bitflags 2.13.2",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
+checksum = "4f10dafd0c8d2e51ae9a748805777613ed0bbe17bf586b76c8311f45c020a32f"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -338,9 +338,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 dependencies = [
  "serde_core",
 ]
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
+checksum = "58a6d0db8759036a783bc7c3f7a07f8cef3bf9470eb1db3bc86e8bcd1c5d0fe8"
 dependencies = [
  "brotli",
  "compression-core",
@@ -674,6 +674,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
 name = "cpufeatures"
@@ -754,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -764,27 +770,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+checksum = "03e8bd762f7479489c70ed6c768ddca99d7296857de437a68dcb2a94365b3fae"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crunchy"
@@ -852,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -862,26 +868,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1105,11 +1111,17 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.35"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+checksum = "7b5ef0006ac9ab233c38522f5ae99cae3625151de8f706cacee1cba4b8e2832a"
 dependencies = [
  "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
 ]
 
 [[package]]
@@ -1425,7 +1437,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "ignore",
  "walkdir",
 ]
@@ -1600,9 +1612,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
 dependencies = [
  "typenum",
 ]
@@ -1863,9 +1875,9 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2095,7 +2107,7 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "libc",
  "plain",
  "redox_syscall 0.9.4",
@@ -2277,6 +2289,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiversion"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ca4bea16ffc3f443cf7d866912118196bfef4c6a1556ca00f9f9b00bb43f7c"
+dependencies = [
+ "multiversion-macros",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d416831a7317ef4b08bee00b69cbbb9c8763da7959a7026244d6266869f9c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,7 +2435,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2691,7 +2730,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2960,7 +2999,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
 ]
 
 [[package]]
@@ -2969,7 +3008,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "737970939a87c6fa31e7acad13307bccbb017a073b695b6089a2c484f929e20e"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
 ]
 
 [[package]]
@@ -3023,11 +3062,11 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3129,7 +3168,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3138,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3293,7 +3332,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3422,11 +3461,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+checksum = "935177bb8c0cd8ca1a4e6d1a2ac8988bea69cab4f9d3a31311e012ad27868ea4"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "chrono",
  "hex",
@@ -3443,14 +3482,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+checksum = "1d607aa01a3cb0ad757d6fd216136910db3c97b102fe686585689615a02dbcdc"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3705,7 +3744,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "byteorder",
  "bytes",
  "crc",
@@ -3748,7 +3787,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "byteorder",
  "crc",
  "dotenvy",
@@ -3880,7 +3919,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4371,7 +4410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4592,9 +4631,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.26.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5063,18 +5102,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5169,18 +5208,18 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+checksum = "bf06bd8162af0734b344780deb55b42a2429ae430870d13fcc12f238e880fe6e"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.3.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d80649ab6db9d9f6f9c80a40becd948eda4714a0a5ac8c4d157a32231c7882"
+checksum = "ae42c0555055784c70058d19ba8e275528e8a99a706684868ace5da4e716a4ab"
 dependencies = [
  "zstd-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,18 +346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bittorrent-primitives"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b47ab263cb9c3bc8be80e312f81c1ee94d3af3d9ee066b81abc06f8fc851023"
-dependencies = [
- "binascii",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,7 +906,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -1965,7 +1953,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.20",
+ "thiserror",
  "walkdir",
  "windows-link",
 ]
@@ -2853,7 +2841,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -2876,7 +2864,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.20",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3601,7 +3589,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
 ]
 
@@ -3690,7 +3678,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
  "tokio",
  "tokio-stream",
@@ -3773,7 +3761,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
  "tracing",
  "whoami",
@@ -3811,7 +3799,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
  "tracing",
  "whoami",
@@ -3836,7 +3824,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
  "tracing",
  "url",
@@ -3971,31 +3959,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.20",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4243,7 +4211,6 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-server",
- "bittorrent-primitives",
  "bytes",
  "chrono",
  "clap",
@@ -4277,12 +4244,13 @@ dependencies = [
  "sqlx",
  "tempfile",
  "tera",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "toml 1.1.5+spec-1.1.0",
  "torrust-index-cli-common",
  "torrust-index-config",
  "torrust-index-render-text-as-image",
+ "torrust-info-hash",
  "tower",
  "tower-http",
  "tracing",
@@ -4327,7 +4295,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.20",
+ "thiserror",
  "toml 1.1.5+spec-1.1.0",
  "tracing",
  "url",
@@ -4372,6 +4340,17 @@ version = "0.1.0"
 dependencies = [
  "ab_glyph",
  "image",
+]
+
+[[package]]
+name = "torrust-info-hash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7d0de6ae3ee4cf86805f87900b60ccc3dbee38e718023bf4636d050fb96b28"
+dependencies = [
+ "binascii",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,12 @@ torrust-index-config = { version = "0.1.0", path = "packages/index-config" }
 torrust-index-render-text-as-image = { version = "0.1.0", path = "packages/render-text-as-image" }
 
 # argon2 and pbkdf2 must stay on one `password-hash` major: the password
-# verification path in `src/services/authentication.rs` builds a `PasswordHash`
-# from one crate and verifies it with the other, so a mismatch is a type error.
-# Both are held to the 0.x line the sources are written against; a bare `0`
-# requirement admits every breaking 0.x release and had let them drift apart.
-argon2 = "0.5"
+# verification path in `src/services/authentication.rs` parses a stored hash
+# once and verifies it with whichever of the two the hash names, so a mismatch
+# is a type error. Raising one without the other reproduces it immediately:
+# rustc reports "multiple different versions of crate `password_hash` in the
+# dependency graph" at the shared verification site.
+argon2 = { version = "0.6", features = ["getrandom"] }
 async-trait = "0.1"
 axum = { version = "0.8", features = ["multipart"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
@@ -87,7 +88,7 @@ lettre = { version = "0.11", features = [
 ] }
 log = "0.4"
 mockall = "0.15"
-pbkdf2 = { version = "0.12", features = ["simple"] }
+pbkdf2 = { version = "0.13", features = ["phc"] }
 pin-project-lite = "0.2"
 rand = "0.10"
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ argon2 = "0.5"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["multipart"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
-bittorrent-primitives = "0.2"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
@@ -106,6 +105,7 @@ tera = { version = "1", default-features = false }
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 toml = "1"
+torrust-info-hash = { version = "0.2", features = ["serde"] }
 tower = { version = "0.5", features = ["timeout"] }
 # Held at 0.6: tower-http 0.7 changes response behaviour for features this
 # workspace enables. Adopting it is an API decision, not a lock refresh.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,9 +107,7 @@ tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi
 toml = "1"
 torrust-info-hash = { version = "0.2", features = ["serde"] }
 tower = { version = "0.5", features = ["timeout"] }
-# Held at 0.6: tower-http 0.7 changes response behaviour for features this
-# workspace enables. Adopting it is an API decision, not a lock refresh.
-tower-http = { version = "0.6", features = ["compression-full", "cors", "propagate-header", "request-id", "trace"] }
+tower-http = { version = "0.7", features = ["compression-full", "cors", "propagate-header", "request-id", "trace"] }
 tracing = "0.1"
 url = { version = "2", features = ["serde"] }
 urlencoding = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ http-body = "1"
 hyper = "1"
 hyper-util = { version = "0.1", features = ["http1", "http2", "tokio"] }
 indexmap = "2"
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+jsonwebtoken = { version = "11", features = ["rust_crypto"] }
 lettre = { version = "0.11", features = [
     "builder",
     "file-transport-envelope",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,25 +60,25 @@ torrust-index-render-text-as-image = { version = "0.1.0", path = "packages/rende
 # Both are held to the 0.x line the sources are written against; a bare `0`
 # requirement admits every breaking 0.x release and had let them drift apart.
 argon2 = "0.5"
-async-trait = "0"
-axum = { version = "0", features = ["multipart"] }
-axum-server = { version = "0", features = ["tls-rustls"] }
+async-trait = "0.1"
+axum = { version = "0.8", features = ["multipart"] }
+axum-server = { version = "0.8", features = ["tls-rustls"] }
 bittorrent-primitives = "0.2"
 bytes = "1"
-chrono = { version = "0", default-features = false, features = ["clock"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 derive_more = { version = "2", features = ["display"] }
-email_address = "0"
-figment = { version = "0", features = ["env", "test", "toml"] }
-futures-util = "0"
-hex = "0"
+email_address = "0.2"
+figment = { version = "0.10", features = ["env", "test", "toml"] }
+futures-util = "0.3"
+hex = "0.4"
 http = "1"
 http-body = "1"
 hyper = "1"
-hyper-util = { version = "0", features = ["http1", "http2", "tokio"] }
+hyper-util = { version = "0.1", features = ["http1", "http2", "tokio"] }
 indexmap = "2"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
-lettre = { version = "0", features = [
+lettre = { version = "0.11", features = [
     "builder",
     "file-transport-envelope",
     "smtp-transport",
@@ -86,31 +86,31 @@ lettre = { version = "0", features = [
     "tokio1-native-tls",
     "tokio1-rustls-tls",
 ] }
-log = "0"
-mockall = "0"
+log = "0.4"
+mockall = "0.15"
 pbkdf2 = { version = "0.12", features = ["simple"] }
-pin-project-lite = "0"
+pin-project-lite = "0.2"
 rand = "0.10"
 regex = "1"
 rsa = { version = "0.9", default-features = false, features = ["std", "pem"] }
-reqwest = { version = "0", features = ["json", "multipart", "query"] }
+reqwest = { version = "0.13", features = ["json", "multipart", "query"] }
 serde = { version = "1", features = ["derive", "rc"] }
-serde_bencode = "0"
-serde_bytes = "0"
+serde_bencode = "0.2"
+serde_bytes = "0.11"
 serde_derive = "1"
 serde_json = "1"
-sha-1 = "0"
-sha2 = "0"
-sqlx = { version = "0", features = ["migrate", "mysql", "runtime-tokio-native-tls", "sqlite", "time"] }
+sha-1 = "0.10"
+sha2 = "0.11"
+sqlx = { version = "0.8", features = ["migrate", "mysql", "runtime-tokio-native-tls", "sqlite", "time"] }
 tera = { version = "1", default-features = false }
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 toml = "1"
-tower = { version = "0", features = ["timeout"] }
+tower = { version = "0.5", features = ["timeout"] }
 # Held at 0.6: tower-http 0.7 changes response behaviour for features this
 # workspace enables. Adopting it is an API decision, not a lock refresh.
 tower-http = { version = "0.6", features = ["compression-full", "cors", "propagate-header", "request-id", "trace"] }
-tracing = "0"
+tracing = "0.1"
 url = { version = "2", features = ["serde"] }
 urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ serde_json = "1"
 sha-1 = "0.10"
 sha2 = "0.11"
 sqlx = { version = "0.8", features = ["migrate", "mysql", "runtime-tokio-native-tls", "sqlite", "time"] }
-tera = { version = "1", default-features = false }
+tera = { version = "2", default-features = false }
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 toml = "1"

--- a/packages/index-auth-keypair/Cargo.toml
+++ b/packages/index-auth-keypair/Cargo.toml
@@ -16,7 +16,7 @@ torrust-index-cli-common = { version = "0.1.0", path = "../index-cli-common" }
 clap = { version = "4", features = ["derive"] }
 rsa = { version = "0.9", default-features = false, features = ["std", "pem"] }
 serde = { version = "1", features = ["derive"] }
-tracing = "0"
+tracing = "0.1"
 
 [dev-dependencies]
 serde_json = "1"

--- a/packages/index-cli-common/Cargo.toml
+++ b/packages/index-cli-common/Cargo.toml
@@ -14,8 +14,8 @@ version = "0.1.0"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tracing = "0"
-tracing-subscriber = { version = "0", features = ["env-filter", "json"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 url = "2"
 
 [lints]

--- a/packages/index-config-probe/Cargo.toml
+++ b/packages/index-config-probe/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4", features = ["derive"] }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tracing = "0"
+tracing = "0.1"
 url = "2"
 
 [lints]

--- a/packages/index-config/Cargo.toml
+++ b/packages/index-config/Cargo.toml
@@ -13,14 +13,14 @@ version = "0.1.0"
 [dependencies]
 camino = { version = "1", features = ["serde"] }
 derive_more = { version = "2", features = ["display"] }
-figment = { version = "0", default-features = false, features = ["env", "toml"] }
-lettre = { version = "0", default-features = false, features = ["builder", "serde"] }
+figment = { version = "0.10", default-features = false, features = ["env", "toml"] }
+lettre = { version = "0.11", default-features = false, features = ["builder", "serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3"
 thiserror = "2"
 toml = "1"
-tracing = "0"
+tracing = "0.1"
 url = { version = "2", features = ["serde"] }
 
 [lints]

--- a/packages/index-health-check/Cargo.toml
+++ b/packages/index-health-check/Cargo.toml
@@ -15,7 +15,7 @@ torrust-index-cli-common = { version = "0.1.0", path = "../index-cli-common" }
 
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
-tracing = "0"
+tracing = "0.1"
 
 [dev-dependencies]
 serde_json = "1"

--- a/packages/mudlark/Cargo.toml
+++ b/packages/mudlark/Cargo.toml
@@ -26,15 +26,15 @@ serde = ["dep:serde"]
 [dependencies]
 rand_core = { version = "0.10", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-tracing = "0"
+tracing = "0.1"
 
 [dev-dependencies]
-criterion = { version = "0", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 rand = "0.10"
 rand_core = { version = "0.10" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tracing-subscriber = { version = "0", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [package.metadata.cargo-machete]
 ignored = ["rand"]

--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use bittorrent_primitives::info_hash::InfoHash;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use torrust_info_hash::InfoHash;
 use url::Url;
 
 use crate::databases::mysql::Mysql;

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -2,10 +2,10 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use bittorrent_primitives::info_hash::InfoHash;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use sqlx::mysql::{MySqlConnectOptions, MySqlPoolOptions};
 use sqlx::{Acquire, ConnectOptions, MySqlPool, query, query_as};
+use torrust_info_hash::InfoHash;
 use url::Url;
 
 use super::database::{TABLES_TO_TRUNCATE, UsersFilters, UsersSorting};

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -2,10 +2,10 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use bittorrent_primitives::info_hash::InfoHash;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Acquire, ConnectOptions, SqlitePool, query, query_as};
+use torrust_info_hash::InfoHash;
 use url::Url;
 
 use super::database::{TABLES_TO_TRUNCATE, UsersFilters, UsersSorting};

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -102,6 +102,13 @@ impl From<argon2::password_hash::Error> for AuthError {
     }
 }
 
+impl From<argon2::password_hash::phc::Error> for AuthError {
+    fn from(e: argon2::password_hash::phc::Error) -> Self {
+        error!(error = %e, "password hash string error");
+        Self::InternalServerError
+    }
+}
+
 // ── UserError ────────────────────────────────────────────────────────
 
 /// Domain error for user management operations.

--- a/src/mailer.rs
+++ b/src/mailer.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::sync::{Arc, LazyLock};
 
 use lettre::message::{MessageBuilder, MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::{Credentials, Mechanism};
 use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
-use serde_json::value::{Value, to_value};
-use tera::{Context, Tera, try_get_value};
+use tera::{Context, Kwargs, State, Tera, TeraResult};
 use thiserror::Error;
 use tracing::error;
 
@@ -49,27 +47,31 @@ fn build_templates() -> Result<Tera, MailTemplateError> {
         Err(source) => return Err(MailTemplateError::ReadOverride { source }),
     };
 
+    // The filter and the escaping rules are installed before the template is
+    // added: tera 2 resolves filter names when it compiles a template, so a
+    // template that pipes through `do_nothing` fails to compile unless the
+    // filter is already registered.
+    tera.autoescape_on(vec![".html", ".sql"]);
+    tera.register_filter("do_nothing", do_nothing_filter);
+
     tera.add_raw_template("html_verify_email", &template)
         .map_err(|source| MailTemplateError::RegisterTemplate { source })?;
 
-    tera.autoescape_on(vec![".html", ".sql"]);
-    tera.register_filter("do_nothing", do_nothing_filter);
     Ok(tera)
 }
 
 /// This function is a dummy filter for tera.
 ///
-/// # Panics
-///
-/// Panics if unable to convert values.
+/// It returns its input unchanged. Deployers who override
+/// `templates/verify.html` can pipe a value through `do_nothing` where a
+/// filter is syntactically required but no transformation is wanted.
 ///
 /// # Errors
 ///
-/// This function will return an error if...
-#[allow(clippy::implicit_hasher)]
-pub fn do_nothing_filter(value: &Value, _: &HashMap<String, Value>) -> tera::Result<Value> {
-    let s = try_get_value!("do_nothing_filter", "value", String, value);
-    Ok(to_value(s).unwrap())
+/// This function does not fail; the result type is the one tera requires of
+/// a filter.
+pub fn do_nothing_filter(value: &str, _: Kwargs, _: &State<'_>) -> TeraResult<String> {
+    Ok(value.to_string())
 }
 
 pub struct Service {

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -103,7 +103,7 @@ impl TorrentResponse {
             canonical_info_hash_group: canonical_info_hash_group
                 .original_info_hashes
                 .iter()
-                .map(bittorrent_primitives::info_hash::InfoHash::to_hex_string)
+                .map(torrust_info_hash::InfoHash::to_hex_string)
                 .collect(),
         }
     }

--- a/src/models/torrent_file.rs
+++ b/src/models/torrent_file.rs
@@ -1,8 +1,8 @@
-use bittorrent_primitives::info_hash::InfoHash;
 use serde::{Deserialize, Serialize};
 use serde_bencode::ser;
 use serde_bytes::ByteBuf;
 use sha1::{Digest, Sha1};
+use torrust_info_hash::InfoHash;
 use tracing::error;
 use url::Url;
 

--- a/src/services/authentication.rs
+++ b/src/services/authentication.rs
@@ -13,7 +13,8 @@
 //! rejects banned users in a single code path.
 use std::sync::Arc;
 
-use argon2::{Argon2, PasswordHash, PasswordVerifier};
+use argon2::password_hash::phc::PasswordHash;
+use argon2::{Argon2, PasswordVerifier};
 use pbkdf2::Pbkdf2;
 
 use super::user::DbUserProfileRepository;
@@ -215,7 +216,7 @@ pub fn verify_password(password: &[u8], user_authentication: &UserAuthentication
             Ok(())
         }
         "pbkdf2-sha256" => {
-            if Pbkdf2.verify_password(password, &parsed_hash).is_err() {
+            if Pbkdf2::default().verify_password(password, &parsed_hash).is_err() {
                 return Err(AuthError::InvalidPassword);
             }
 

--- a/src/services/torrent.rs
+++ b/src/services/torrent.rs
@@ -2,8 +2,8 @@
 use std::fmt::Write as _;
 use std::sync::Arc;
 
-use bittorrent_primitives::info_hash::InfoHash;
 use serde_derive::{Deserialize, Serialize};
+use torrust_info_hash::InfoHash;
 use tracing::debug;
 use url::Url;
 

--- a/src/services/user.rs
+++ b/src/services/user.rs
@@ -2,13 +2,11 @@
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 
-use argon2::password_hash::SaltString;
 use argon2::{Argon2, PasswordHasher};
 use async_trait::async_trait;
 use chrono::NaiveDate;
 #[cfg(test)]
 use mockall::automock;
-use pbkdf2::password_hash::rand_core::OsRng;
 use serde_derive::Deserialize;
 use tracing::{debug, info, warn};
 
@@ -581,13 +579,12 @@ fn validate_password_constraints(
 }
 
 fn hash_password(password: &str) -> Result<String, UserError> {
-    let salt = SaltString::generate(&mut OsRng);
-
     // Argon2 with default params (Argon2id v19)
     let argon2 = Argon2::default();
 
-    // Hash password to PHC string ($argon2id$v=19$...)
-    let password_hash = argon2.hash_password(password.as_bytes(), &salt)?.to_string();
+    // Hash password to PHC string ($argon2id$v=19$...). The salt is drawn from
+    // the operating system for each call and carried in the string itself.
+    let password_hash = argon2.hash_password(password.as_bytes())?.to_string();
 
     Ok(password_hash)
 }

--- a/src/tests/errors/auth_error.rs
+++ b/src/tests/errors/auth_error.rs
@@ -170,6 +170,6 @@ fn from_database_fallback() {
 
 #[test]
 fn from_argon2_error() {
-    let err: AuthError = argon2::password_hash::Error::Password.into();
+    let err: AuthError = argon2::password_hash::Error::PasswordInvalid.into();
     assert_eq!(err, AuthError::InternalServerError);
 }

--- a/src/tests/errors/user_error.rs
+++ b/src/tests/errors/user_error.rs
@@ -308,7 +308,7 @@ fn from_database_fallback() {
 
 #[test]
 fn from_argon2_error() {
-    let err: UserError = argon2::password_hash::Error::Password.into();
+    let err: UserError = argon2::password_hash::Error::PasswordInvalid.into();
     assert_eq!(err, UserError::InternalServerError);
 }
 

--- a/src/tests/mailer.rs
+++ b/src/tests/mailer.rs
@@ -1,5 +1,5 @@
 use lettre::Message;
-use serde_json::json;
+use tera::{Context, Tera};
 
 use crate::mailer::{build_content, build_letter, do_nothing_filter};
 
@@ -22,8 +22,12 @@ fn it_should_build_content() {
 
 #[test]
 fn do_nothing_filter_passes_through_string() {
-    let input = json!("hello world");
-    let args = std::collections::HashMap::new();
-    let result = do_nothing_filter(&input, &args).unwrap();
-    assert_eq!(result, json!("hello world"));
+    let mut tera = Tera::default();
+    tera.register_filter("do_nothing", do_nothing_filter);
+    tera.add_raw_template("passthrough", "{{ value | do_nothing }}").unwrap();
+
+    let mut context = Context::new();
+    context.insert("value", "hello world");
+
+    assert_eq!(tera.render("passthrough", &context).unwrap(), "hello world");
 }

--- a/src/tests/utils/parse_torrent.rs
+++ b/src/tests/utils/parse_torrent.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use bittorrent_primitives::info_hash::InfoHash;
+use torrust_info_hash::InfoHash;
 
 /// Returns a torrent file binary contents for a torrent with a custom key
 /// inside the `info` dictionary. A custom key means a key not included in

--- a/src/utils/parse_torrent.rs
+++ b/src/utils/parse_torrent.rs
@@ -1,11 +1,11 @@
 use std::error;
 
-use bittorrent_primitives::info_hash::InfoHash;
 use serde::{Deserialize, Serialize};
 use serde_bencode::value::Value;
 use serde_bencode::{Error as SerdeError, de};
 use sha1::{Digest, Sha1};
 use thiserror::Error;
+use torrust_info_hash::InfoHash;
 
 use crate::models::torrent_file::Torrent;
 

--- a/src/web/api/server/v1/contexts/torrent/handlers.rs
+++ b/src/web/api/server/v1/contexts/torrent/handlers.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use axum::Json;
 use axum::extract::{self, Multipart, Path, Query, State};
 use axum::response::{IntoResponse, Redirect, Response};
-use bittorrent_primitives::info_hash::InfoHash;
 use serde::Deserialize;
+use torrust_info_hash::InfoHash;
 use tracing::debug;
 use uuid::Uuid;
 

--- a/tests/e2e/web/api/v1/contexts/torrent/steps.rs
+++ b/tests/e2e/web/api/v1/contexts/torrent/steps.rs
@@ -2,8 +2,8 @@
 
 use std::str::FromStr;
 
-use bittorrent_primitives::info_hash::InfoHash;
 use torrust_index::web::api::server::v1::responses::ErrorResponseData;
+use torrust_info_hash::InfoHash;
 
 use crate::common::client::Client;
 use crate::common::contexts::torrent::fixtures::{TestTorrent, TorrentIndexInfo, TorrentListedInIndex, random_torrent};

--- a/tests/upgrades/from_v1_0_0_to_v2_0_0/transferrer_testers/user_transferrer_tester.rs
+++ b/tests/upgrades/from_v1_0_0_to_v2_0_0/transferrer_testers/user_transferrer_tester.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use argon2::password_hash::SaltString;
 use argon2::{Argon2, PasswordHasher};
 use torrust_index::upgrades::from_v1_0_0_to_v2_0_0::databases::sqlite_v1_0_0::UserRecordV1;
 
@@ -105,11 +104,9 @@ fn valid_password() -> String {
 }
 
 fn hash_password(plain_password: &str) -> String {
-    let salt = SaltString::generate(&mut argon2::password_hash::rand_core::OsRng);
-
     // Argon2 with default params (Argon2id v19)
     let argon2 = Argon2::default();
 
     // Hash password to PHC string ($argon2id$v=19$...)
-    argon2.hash_password(plain_password.as_bytes(), &salt).unwrap().to_string()
+    argon2.hash_password(plain_password.as_bytes()).unwrap().to_string()
 }


### PR DESCRIPTION
Every dependency of the workspace taken to its newest release under the 1.89 floor, majors included, in one reviewable series. It supersedes the open per-dependency bump pull requests, each of which is covered here together with the source migration its major needs.

Closes #885, closes #886, closes #887, closes #888, closes #889, closes #890, closes #876, closes #875.

## The series

Nine commits, one concern each, every one of which compiles and passes the workspace on its own:

1. **Narrow the bare `0` requirements.** Thirty-two requirements of the form `0` — the whole pre-1.0 range, in which every release may break — are narrowed to the `0.x` line the sources are actually written against. Declarative only: the lock is untouched and nothing moves. It matters for the next commit, because under a bare `0` a plain `cargo update` crosses 0.x majors silently.
2. **Lock refresh.** `cargo update` on the MSRV-aware resolver: 23 entries updated, 4 added (the `multiversion` family beneath `encoding_rs`, `zstd` 0.14 beneath `async-compression`), none removed or downgraded. No locked crate declares a `rust-version` above 1.89.
3. **`bittorrent-primitives` → `torrust-info-hash` 0.2.** `bittorrent-primitives` 0.3 deprecates its entire surface with the message *migrate to the torrust-info-hash crate*; under `warnings = deny` that release is a hard error, not a bump. The successor carries the same `InfoHash` with the same constructors, `to_hex_string`, `FromStr`, `Display` and serde form; the migration is ten import paths and one qualified reference. Persisted and served infohashes are unchanged.
4. **`jsonwebtoken` 10 → 11.** Every item the workspace uses keeps its path and shape; no source change.
5. **`tower-http` 0.6 → 0.7.** All five layers the router is built from are unchanged in 0.7; what moved is compression negotiation, which the workspace drives through `compression-full` defaults and never configures by hand. The manifest note that deferred this decision comes off with it. (`reqwest` 0.13 still carries `tower-http` 0.6 internally, so both lines remain in the lock until it moves.)
6. **`argon2` 0.5 → 0.6 with `pbkdf2` 0.12 → 0.13.** The two share a `password-hash` release and cannot move apart — raising one alone yields *multiple different versions of crate `password_hash` in the dependency graph* at the shared verification site. `password-hash` 0.6 splits PHC parsing into the `phc` crate, renames `Error::Password` to `PasswordInvalid`, and draws the salt inside `hash_password`; the hand-rolled `SaltString`/`OsRng` salt goes with no change in behaviour. **Stored hashes keep verifying**: the PHC string carries algorithm, version, parameters and salt, so each hash is read back with the parameters it was written under. The two in-tree tests holding literal `$argon2id$…` and `$pbkdf2-sha256$…` strings produced under the previous releases pass unchanged.
7. **`tera` 1 → 2.** The template language is unchanged; the Rust API for custom filters is not. `do_nothing_filter` is now typed (`&str` → `String`) instead of macro-checked at runtime, and its test drives it through a real render. One latent ordering bug surfaced and is fixed: tera 2 resolves filter names when it compiles a template, so the filter is now registered before the template is added — the shipped template does not use the filter, but a deployer's override of `templates/verify.html` could.
8. **CHANGELOG** entry under Unreleased.
9. **GitHub Actions**: `actions/checkout` v7, `codecov/codecov-action` v7, `taiki-e/install-action` 2.87.9, the newest release the repository's Actions allow-list admits. Last and alone, so it can be dropped whole without disturbing the dependency work in front of it.

## Left where it is

- `sqlx` 0.9 requires Rust 1.94, above the 1.89 floor of ADR-T-011; it stays at 0.8.6.
- `camino`, `crypto-common` and `matchit` sit behind newer patch releases the resolver declines even with the MSRV gate lifted; none crosses a major.
- `cargo audit`: RUSTSEC-2023-0071 (`rsa`, no fixed release exists) and RUSTSEC-2026-0192 (`ttf-parser` unmaintained, via `ab_glyph`) — both present at the base at these exact versions and neither has a newer release.

## Verification

At the head commit, on the workspace with all targets and all features: clippy on nightly and on stable (0 warnings), `cargo fmt --check` empty, `cargo +1.89.0 check --locked`, rustdoc with warnings denied (0), the whole-workspace test run with `--no-fail-fast` (60 suites, 1,919 passed, 0 failed, 6 ignored), and `cargo metadata` confirming no locked entry above the floor. The MSRV recompute ADR-T-011 asks of each maintenance pass gives 1.89 again (1.90.0 shipped 2025-09-18, under a year old); nothing changes.
