### PR TITLE
build: declare the repository's symbolic link for the merge tool

### DIFF
--- a/.symlinks.json
+++ b/.symlinks.json
@@ -1,0 +1,11 @@
+{
+  "namespace": "com.torrust.repository.symlinks",
+  "version": [1, 0, 0],
+  "symlinks": [
+    {
+      "path": ".dockerignore",
+      "target": ".containerignore",
+      "reason": "Docker reads only .dockerignore, while Podman and Buildah prefer .containerignore. The link lets one ignore list serve both toolchains instead of two files that drift apart."
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.symlinks.json` at the repository root, declaring the one symbolic link this tree carries on purpose: `.dockerignore` pointing at `.containerignore`, so that one ignore list serves Docker, which reads only the former, and Podman and Buildah, which prefer the latter.

The maintainer merge tool shared across the Torrust repositories lists every commit a merge introduces and refuses each symbolic link it finds unless a declaration in the final merged tree admits that exact path with that exact target. Until this file is in the tree, every pull request merged through the tool stops at that link; once it is, the tool prints the accepted link with its reason before asking the maintainer to sign.

The declaration format is the tool's: `namespace` names the format rather than this repository, and `version` is the format's version. One file, eleven lines, no other change. Validated against the tool's own reader, which accepts the link and reports no problem.
